### PR TITLE
feat: add Python ecosystem support with EcosystemAdapter trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +156,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "changelogs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -157,11 +169,13 @@ dependencies = [
  "regex",
  "semver",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror",
  "toml",
  "toml_edit",
+ "ureq",
 ]
 
 [[package]]
@@ -252,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +320,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -356,12 +390,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -410,6 +474,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -472,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +669,16 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -555,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +750,15 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -623,7 +820,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -665,6 +862,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +895,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -817,16 +1063,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -840,13 +1104,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -879,6 +1154,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -947,6 +1232,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1337,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1091,6 +1436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -1191,6 +1545,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1587,66 @@ name = "zerocopy-derive"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,9 @@ rand = "0.9"
 chrono = "0.4"
 regex = "1"
 
+# HTTP (for PyPI API)
+ureq = { version = "2", features = ["json"] }
+serde_json = "1"
+
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,70 @@ flowchart LR
 | `version` | Apply version bumps and update changelogs |
 | `publish` | Publish unpublished packages to crates.io |
 
+## Python Support
+
+Changelogs supports Python packages using PEP 621 `pyproject.toml` files.
+
+### Requirements
+
+- **PEP 621 metadata**: Your `pyproject.toml` must have a `[project]` section with `name` and `version`
+- **Static version**: Dynamic versions (`dynamic = ["version"]`) are not supported
+- **Semantic versioning**: Versions must be valid semver (e.g., `1.2.3`, not PEP 440 epochs or local versions)
+- **Build tools**: `python -m build` and `twine` must be installed
+
+### Setup
+
+```bash
+# Install build dependencies
+pip install build twine
+
+# Initialize changelogs
+changelogs init --ecosystem python
+```
+
+### Publishing
+
+```bash
+# Publish to PyPI (uses TWINE_USERNAME/TWINE_PASSWORD or ~/.pypirc)
+changelogs publish
+```
+
+For CI, set `TWINE_USERNAME` and `TWINE_PASSWORD` environment variables (use `__token__` as username for API tokens).
+
+### GitHub Actions for Python
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - run: pip install build twine
+      
+      - uses: wevm/changelogs-rs@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+```
+
+### Limitations
+
+- Single-package repos only (no Python monorepo support)
+- PEP 621 `pyproject.toml` only (no `setup.py` or `setup.cfg`)
+- Semantic versioning only (no PEP 440 epochs, post releases, or local versions)
+
 ## Configuration
 
 `.changelog/config.toml`:

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,14 @@ branding:
   color: 'orange'
 
 inputs:
+  ecosystem:
+    description: 'Ecosystem to use (rust, python). Auto-detected if not specified.'
+    required: false
   crate-token:
-    description: 'Crates.io API token for publishing'
+    description: 'Crates.io API token for publishing (Rust)'
+    required: false
+  pypi-token:
+    description: 'PyPI API token for publishing (Python)'
     required: false
   commit:
     description: 'Commit message for version bump (overrides conventional-commit)'
@@ -45,6 +51,17 @@ runs:
   steps:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+
+    - name: Setup Python (for Python ecosystem)
+      if: inputs.ecosystem == 'python' || inputs.pypi-token != ''
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install Python build tools (for Python ecosystem)
+      if: inputs.ecosystem == 'python' || inputs.pypi-token != ''
+      shell: bash
+      run: pip install build twine
 
     - name: Cache changelogs binary
       id: cache
@@ -83,7 +100,11 @@ runs:
       id: version
       shell: bash
       run: |
-        output=$(changelogs version 2>&1)
+        ECOSYSTEM_FLAG=""
+        if [ -n "${{ inputs.ecosystem }}" ]; then
+          ECOSYSTEM_FLAG="--ecosystem ${{ inputs.ecosystem }}"
+        fi
+        output=$(changelogs $ECOSYSTEM_FLAG version 2>&1)
         echo "$output"
         
         # Extract versions from output (e.g., "changelogs 0.0.1 → 0.1.0" -> "changelogs@0.1.0")
@@ -149,22 +170,28 @@ runs:
         commit-message: ${{ inputs.commit || steps.version.outputs.commit-msg }}
         delete-branch: true
 
-    # Publish mode: Publish when no changelogs (PR was just merged) and crate-token provided
+    # Publish mode: Publish when no changelogs (PR was just merged) and a registry token is provided
     - name: Setup Git user for tags
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.crate-token != ''
+      if: steps.check.outputs.hasChangelogs == 'false' && (inputs.crate-token != '' || inputs.pypi-token != '')
       shell: bash
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
     - name: Publish packages
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.crate-token != ''
+      if: steps.check.outputs.hasChangelogs == 'false' && (inputs.crate-token != '' || inputs.pypi-token != '')
       id: publish
       shell: bash
       env:
         CARGO_REGISTRY_TOKEN: ${{ inputs.crate-token }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ inputs.pypi-token }}
       run: |
-        output=$(changelogs publish 2>&1) || true
+        ECOSYSTEM_FLAG=""
+        if [ -n "${{ inputs.ecosystem }}" ]; then
+          ECOSYSTEM_FLAG="--ecosystem ${{ inputs.ecosystem }}"
+        fi
+        output=$(changelogs $ECOSYSTEM_FLAG publish 2>&1) || true
         echo "$output"
         
         # Parse published packages from output
@@ -179,12 +206,12 @@ runs:
         fi
 
     - name: Push git tags
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.crate-token != '' && steps.publish.outputs.published == 'true'
+      if: steps.check.outputs.hasChangelogs == 'false' && (inputs.crate-token != '' || inputs.pypi-token != '') && steps.publish.outputs.published == 'true'
       shell: bash
       run: git push --follow-tags
 
     - name: Create GitHub releases
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.crate-token != '' && steps.publish.outputs.published == 'true'
+      if: steps.check.outputs.hasChangelogs == 'false' && (inputs.crate-token != '' || inputs.pypi-token != '') && steps.publish.outputs.published == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/src/changelog_entry.rs
+++ b/src/changelog_entry.rs
@@ -187,7 +187,7 @@ pub fn read_all(changelog_dir: &Path) -> Result<Vec<Changelog>> {
         let entry = entry?;
         let path = entry.path();
 
-        if path.extension().map_or(false, |ext| ext == "md") {
+        if path.extension().is_some_and(|ext| ext == "md") {
             let filename = path.file_stem().unwrap().to_string_lossy().to_string();
 
             if filename == "README" {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,15 +1,15 @@
 use changelogs::changelog_entry;
 use changelogs::error::Error;
 use changelogs::workspace::Workspace;
-use changelogs::{BumpType, Changelog, Release};
+use changelogs::{BumpType, Changelog, Ecosystem, Release};
 use anyhow::Result;
 use console::style;
 use inquire::{MultiSelect, Select, Text};
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-pub fn run(empty: bool, ai: Option<String>, instructions: Option<String>, base_ref: Option<String>) -> Result<()> {
-    let workspace = Workspace::discover().map_err(|_| Error::NotInWorkspace)?;
+pub fn run(empty: bool, ai: Option<String>, instructions: Option<String>, base_ref: Option<String>, ecosystem: Option<Ecosystem>) -> Result<()> {
+    let workspace = Workspace::discover_with_ecosystem(ecosystem).map_err(|_| Error::NotInWorkspace)?;
 
     if !workspace.is_initialized() {
         return Err(Error::NotInitialized.into());

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,11 +1,12 @@
 use changelogs::config::Config;
 use changelogs::error::Error;
 use changelogs::workspace::Workspace;
+use changelogs::Ecosystem;
 use anyhow::Result;
 use console::style;
 
-pub fn run() -> Result<()> {
-    let workspace = Workspace::discover().map_err(|_| Error::NotInWorkspace)?;
+pub fn run(ecosystem: Option<Ecosystem>) -> Result<()> {
+    let workspace = Workspace::discover_with_ecosystem(ecosystem).map_err(|_| Error::NotInWorkspace)?;
 
     if workspace.is_initialized() {
         return Err(Error::AlreadyInitialized.into());

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -3,12 +3,12 @@ use changelogs::config::Config;
 use changelogs::error::Error;
 use changelogs::plan;
 use changelogs::workspace::Workspace;
-use changelogs::BumpType;
+use changelogs::{BumpType, Ecosystem};
 use anyhow::Result;
 use console::style;
 
-pub fn run(verbose: bool) -> Result<()> {
-    let workspace = Workspace::discover().map_err(|_| Error::NotInWorkspace)?;
+pub fn run(verbose: bool, ecosystem: Option<Ecosystem>) -> Result<()> {
+    let workspace = Workspace::discover_with_ecosystem(ecosystem).map_err(|_| Error::NotInWorkspace)?;
 
     if !workspace.is_initialized() {
         return Err(Error::NotInitialized.into());

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -4,13 +4,14 @@ use changelogs::config::Config;
 use changelogs::error::Error;
 use changelogs::plan;
 use changelogs::workspace::Workspace;
+use changelogs::Ecosystem;
 use anyhow::Result;
 use console::style;
 use semver::Version;
 use std::collections::HashMap;
 
-pub fn run() -> Result<()> {
-    let workspace = Workspace::discover().map_err(|_| Error::NotInWorkspace)?;
+pub fn run(ecosystem: Option<Ecosystem>) -> Result<()> {
+    let workspace = Workspace::discover_with_ecosystem(ecosystem).map_err(|_| Error::NotInWorkspace)?;
 
     if !workspace.is_initialized() {
         return Err(Error::NotInitialized.into());

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,13 @@
+use crate::ecosystems::Ecosystem;
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
+    #[serde(default)]
+    pub ecosystem: Option<Ecosystem>,
+
     #[serde(default = "default_dependent_bump")]
     pub dependent_bump: DependentBump,
 
@@ -80,6 +84,7 @@ fn default_changelog_format() -> ChangelogFormat {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            ecosystem: None,
             dependent_bump: default_dependent_bump(),
             changelog: ChangelogConfig::default(),
             fixed: Vec::new(),
@@ -112,18 +117,21 @@ impl Config {
     }
 
     pub fn default_toml() -> &'static str {
-        r#"# How to bump packages that depend on changed packages
+        r#"# Ecosystem: "rust" | "python" (auto-detected if not specified)
+# ecosystem = "rust"
+
+# How to bump packages that depend on changed packages
 # "patch" | "minor" | "none"
 dependent_bump = "patch"
 
 [changelog]
-# "per-crate" - CHANGELOG.md in each crate
+# "per-crate" - CHANGELOG.md in each package
 # "root" - Single CHANGELOG.md at workspace root
 format = "per-crate"
 
-# Fixed groups: all crates always share the same version
+# Fixed groups: all packages always share the same version
 # [[fixed]]
-# members = ["crate-a", "crate-b"]
+# members = ["package-a", "package-b"]
 
 # Linked groups: versions sync when released together
 # [[linked]]

--- a/src/ecosystems/mod.rs
+++ b/src/ecosystems/mod.rs
@@ -1,0 +1,183 @@
+mod python;
+mod rust;
+
+pub use python::PythonAdapter;
+pub use rust::RustAdapter;
+
+use crate::error::Result;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum Ecosystem {
+    #[default]
+    Rust,
+    Python,
+}
+
+impl std::fmt::Display for Ecosystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Ecosystem::Rust => write!(f, "rust"),
+            Ecosystem::Python => write!(f, "python"),
+        }
+    }
+}
+
+impl std::str::FromStr for Ecosystem {
+    type Err = crate::error::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "rust" | "cargo" => Ok(Ecosystem::Rust),
+            "python" | "pypi" => Ok(Ecosystem::Python),
+            _ => Err(crate::error::Error::InvalidEcosystem(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Package {
+    pub name: String,
+    pub version: Version,
+    pub path: PathBuf,
+    pub manifest_path: PathBuf,
+    pub dependencies: Vec<String>,
+}
+
+/// Trait defining ecosystem-specific operations for package management.
+///
+/// Note: Methods are associated functions (not instance methods) because adapters
+/// are stateless. Use the free functions in this module for dispatch by `Ecosystem` enum.
+pub trait EcosystemAdapter {
+    /// Returns the ecosystem identifier.
+    fn ecosystem() -> Ecosystem
+    where
+        Self: Sized;
+
+    /// Discovers packages in the given root directory.
+    fn discover(root: &Path) -> Result<Vec<Package>>
+    where
+        Self: Sized;
+
+    /// Reads the version from a manifest file.
+    fn read_version(manifest_path: &Path) -> Result<Version>
+    where
+        Self: Sized;
+
+    /// Writes a new version to a manifest file.
+    fn write_version(manifest_path: &Path, version: &Version) -> Result<()>
+    where
+        Self: Sized;
+
+    /// Updates a dependency version in a manifest file. Returns true if modified.
+    fn update_dependency_version(
+        manifest_path: &Path,
+        dep_name: &str,
+        new_version: &Version,
+    ) -> Result<bool>
+    where
+        Self: Sized;
+
+    /// Checks if a package version is already published to the registry.
+    fn is_published(name: &str, version: &Version) -> Result<bool>
+    where
+        Self: Sized;
+
+    /// Publishes a package to the registry. Returns true on success.
+    fn publish(pkg: &Package, dry_run: bool, registry: Option<&str>) -> Result<bool>
+    where
+        Self: Sized;
+
+    /// Returns the git tag name for a package release.
+    fn tag_name(pkg: &Package) -> String
+    where
+        Self: Sized,
+    {
+        format!("{}@{}", pkg.name, pkg.version)
+    }
+}
+
+pub fn detect_ecosystem(start: &Path) -> Option<Ecosystem> {
+    let mut current = start.to_path_buf();
+
+    loop {
+        if current.join("Cargo.toml").exists() {
+            return Some(Ecosystem::Rust);
+        }
+        if current.join("pyproject.toml").exists() {
+            return Some(Ecosystem::Python);
+        }
+
+        match current.parent() {
+            Some(parent) => current = parent.to_path_buf(),
+            None => return None,
+        }
+    }
+}
+
+pub fn discover_packages(ecosystem: Ecosystem, root: &Path) -> Result<Vec<Package>> {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::discover(root),
+        Ecosystem::Python => PythonAdapter::discover(root),
+    }
+}
+
+pub fn read_version(ecosystem: Ecosystem, manifest_path: &Path) -> Result<Version> {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::read_version(manifest_path),
+        Ecosystem::Python => PythonAdapter::read_version(manifest_path),
+    }
+}
+
+pub fn write_version(
+    ecosystem: Ecosystem,
+    manifest_path: &Path,
+    version: &Version,
+) -> Result<()> {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::write_version(manifest_path, version),
+        Ecosystem::Python => PythonAdapter::write_version(manifest_path, version),
+    }
+}
+
+pub fn update_dependency_versions(
+    ecosystem: Ecosystem,
+    packages: &[Package],
+    root: &Path,
+    updates: &HashMap<String, Version>,
+) -> Result<()> {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::update_all_dependency_versions(packages, root, updates),
+        Ecosystem::Python => PythonAdapter::update_all_dependency_versions(packages, root, updates),
+    }
+}
+
+pub fn is_published(ecosystem: Ecosystem, name: &str, version: &Version) -> Result<bool> {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::is_published(name, version),
+        Ecosystem::Python => PythonAdapter::is_published(name, version),
+    }
+}
+
+pub fn publish(
+    ecosystem: Ecosystem,
+    pkg: &Package,
+    dry_run: bool,
+    registry: Option<&str>,
+) -> Result<bool> {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::publish(pkg, dry_run, registry),
+        Ecosystem::Python => PythonAdapter::publish(pkg, dry_run, registry),
+    }
+}
+
+pub fn tag_name(ecosystem: Ecosystem, pkg: &Package) -> String {
+    match ecosystem {
+        Ecosystem::Rust => RustAdapter::tag_name(pkg),
+        Ecosystem::Python => PythonAdapter::tag_name(pkg),
+    }
+}

--- a/src/ecosystems/python.rs
+++ b/src/ecosystems/python.rs
@@ -1,0 +1,630 @@
+use crate::ecosystems::{Ecosystem, EcosystemAdapter, Package};
+use crate::error::{Error, Result};
+use semver::Version;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use toml_edit::DocumentMut;
+
+pub struct PythonAdapter;
+
+impl EcosystemAdapter for PythonAdapter {
+    fn ecosystem() -> Ecosystem {
+        Ecosystem::Python
+    }
+
+    fn discover(root: &Path) -> Result<Vec<Package>> {
+        let pyproject_path = root.join("pyproject.toml");
+
+        if !pyproject_path.exists() {
+            return Err(Error::PythonProjectNotFound(format!(
+                "No pyproject.toml found at {}",
+                root.display()
+            )));
+        }
+
+        let content = std::fs::read_to_string(&pyproject_path)?;
+        let doc: DocumentMut = content.parse()?;
+
+        let project = doc.get("project").ok_or_else(|| {
+            Error::PythonProjectNotFound(
+                "pyproject.toml must have a [project] section (PEP 621)".to_string(),
+            )
+        })?;
+
+        let name = project
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::PythonProjectNotFound("project.name is required".to_string()))?;
+
+        if let Some(dynamic) = project.get("dynamic") {
+            if let Some(arr) = dynamic.as_array() {
+                for item in arr.iter() {
+                    if item.as_str() == Some("version") {
+                        return Err(Error::PythonDynamicVersion(
+                            "Dynamic versions are not supported. Use a static version in [project].version".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        let version_str = project.get("version").and_then(|v| v.as_str()).ok_or_else(|| {
+            Error::VersionNotFound("project.version is required and must be static".to_string())
+        })?;
+
+        let version: Version = version_str.parse().map_err(|e| {
+            Error::VersionParse(format!("Invalid semver version '{}': {}", version_str, e))
+        })?;
+
+        let dependencies = Self::extract_dependencies(&doc);
+
+        Ok(vec![Package {
+            name: name.to_string(),
+            version,
+            path: root.to_path_buf(),
+            manifest_path: pyproject_path,
+            dependencies,
+        }])
+    }
+
+    fn read_version(manifest_path: &Path) -> Result<Version> {
+        let content = std::fs::read_to_string(manifest_path)?;
+        let doc: DocumentMut = content.parse()?;
+
+        let version_str = doc
+            .get("project")
+            .and_then(|p| p.get("version"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::VersionNotFound(manifest_path.display().to_string()))?;
+
+        Ok(version_str.parse()?)
+    }
+
+    fn write_version(manifest_path: &Path, version: &Version) -> Result<()> {
+        let content = std::fs::read_to_string(manifest_path)?;
+        let mut doc: DocumentMut = content.parse()?;
+
+        let project = doc
+            .get_mut("project")
+            .and_then(|p| p.as_table_mut())
+            .ok_or_else(|| {
+                Error::PythonProjectNotFound(format!(
+                    "No [project] section in {}",
+                    manifest_path.display()
+                ))
+            })?;
+
+        project["version"] = toml_edit::value(version.to_string());
+
+        std::fs::write(manifest_path, doc.to_string())?;
+        Ok(())
+    }
+
+    fn update_dependency_version(
+        manifest_path: &Path,
+        dep_name: &str,
+        new_version: &Version,
+    ) -> Result<bool> {
+        let content = fs::read_to_string(manifest_path)?;
+        let mut doc: DocumentMut = content.parse()?;
+        let mut modified = false;
+
+        if let Some(project) = doc.get_mut("project") {
+            if let Some(deps) = project.get_mut("dependencies") {
+                if let Some(arr) = deps.as_array_mut() {
+                    for i in 0..arr.len() {
+                        if let Some(dep_str) = arr.get(i).and_then(|v| v.as_str()) {
+                            if Self::dependency_matches(dep_str, dep_name) {
+                                if let Some(new_dep) = Self::rewrite_dependency(dep_str, new_version) {
+                                    arr.replace(i, new_dep);
+                                    modified = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(optional_deps) = project.get_mut("optional-dependencies") {
+                if let Some(table) = optional_deps.as_table_mut() {
+                    for (_key, value) in table.iter_mut() {
+                        if let Some(arr) = value.as_array_mut() {
+                            for i in 0..arr.len() {
+                                if let Some(dep_str) = arr.get(i).and_then(|v| v.as_str()) {
+                                    if Self::dependency_matches(dep_str, dep_name) {
+                                        if let Some(new_dep) = Self::rewrite_dependency(dep_str, new_version) {
+                                            arr.replace(i, new_dep);
+                                            modified = true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if modified {
+            fs::write(manifest_path, doc.to_string())?;
+        }
+
+        Ok(modified)
+    }
+
+    fn is_published(name: &str, version: &Version) -> Result<bool> {
+        let normalized_name = Self::normalize_pep503(name);
+        let url = format!("https://pypi.org/pypi/{}/json", normalized_name);
+
+        let response = match ureq::get(&url).call() {
+            Ok(resp) => resp,
+            Err(ureq::Error::Status(404, _)) => return Ok(false),
+            Err(e) => return Err(Error::PypiCheckFailed(e.to_string())),
+        };
+
+        let json: serde_json::Value = response
+            .into_json()
+            .map_err(|e| Error::PypiCheckFailed(format!("failed to parse JSON: {}", e)))?;
+
+        if let Some(releases) = json.get("releases").and_then(|r| r.as_object()) {
+            let version_str = version.to_string();
+            return Ok(releases.contains_key(&version_str));
+        }
+
+        Ok(false)
+    }
+
+    fn publish(pkg: &Package, dry_run: bool, registry: Option<&str>) -> Result<bool> {
+        if dry_run {
+            return Ok(true);
+        }
+
+        let pkg_path = pkg.path.canonicalize().map_err(|e| {
+            Error::PublishFailed(format!("Failed to canonicalize package path: {}", e))
+        })?;
+        let dist_dir = pkg_path.join("dist");
+
+        if dist_dir.exists() {
+            let canonical_dist = dist_dir.canonicalize().map_err(|e| {
+                Error::PublishFailed(format!("Failed to canonicalize dist path: {}", e))
+            })?;
+            if !canonical_dist.starts_with(&pkg_path) {
+                return Err(Error::PublishFailed(
+                    "dist directory path traversal detected".to_string(),
+                ));
+            }
+            fs::remove_dir_all(&canonical_dist)?;
+        }
+
+        let build_output = Command::new("python")
+            .args(["-m", "build"])
+            .current_dir(&pkg_path)
+            .output()?;
+
+        if !build_output.status.success() {
+            let stderr = String::from_utf8_lossy(&build_output.stderr);
+            return Err(Error::PublishFailed(format!(
+                "python -m build failed: {}",
+                stderr
+            )));
+        }
+
+        let mut dist_files: Vec<_> = fs::read_dir(&dist_dir)?
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                name.ends_with(".whl") || name.ends_with(".tar.gz") || name.ends_with(".zip")
+            })
+            .collect();
+        dist_files.sort();
+
+        if dist_files.is_empty() {
+            return Err(Error::PublishFailed(
+                "No distribution files found in dist/".to_string(),
+            ));
+        }
+
+        let mut cmd = Command::new("twine");
+        cmd.arg("upload");
+
+        if let Some(reg) = registry {
+            match reg.to_lowercase().as_str() {
+                "testpypi" => {
+                    cmd.args(["--repository", "testpypi"]);
+                }
+                url if url.starts_with("http://") || url.starts_with("https://") => {
+                    cmd.args(["--repository-url", reg]);
+                }
+                _ => {
+                    cmd.args(["--repository", reg]);
+                }
+            }
+        }
+
+        for file in &dist_files {
+            cmd.arg(file);
+        }
+        cmd.current_dir(&pkg_path);
+
+        let upload_output = cmd.output()?;
+
+        if upload_output.status.success() {
+            return Ok(true);
+        }
+
+        let stderr = String::from_utf8_lossy(&upload_output.stderr);
+        if stderr.contains("already exists") || stderr.contains("File already exists") {
+            return Ok(true);
+        }
+
+        Err(Error::PublishFailed(format!(
+            "twine upload failed: {}",
+            stderr
+        )))
+    }
+}
+
+impl PythonAdapter {
+    fn extract_dependencies(doc: &DocumentMut) -> Vec<String> {
+        let mut deps = Vec::new();
+
+        if let Some(project) = doc.get("project") {
+            if let Some(dependencies) = project.get("dependencies") {
+                if let Some(arr) = dependencies.as_array() {
+                    for item in arr.iter() {
+                        if let Some(dep_str) = item.as_str() {
+                            if let Some(name) = Self::parse_dependency_name(dep_str) {
+                                deps.push(name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        deps
+    }
+
+    fn normalize_pep503(name: &str) -> String {
+        let lower = name.to_ascii_lowercase();
+        let mut out = String::with_capacity(lower.len());
+        let mut prev_sep = false;
+
+        for ch in lower.chars() {
+            let is_sep = ch == '-' || ch == '_' || ch == '.';
+            if is_sep {
+                if !prev_sep {
+                    out.push('-');
+                    prev_sep = true;
+                }
+            } else {
+                out.push(ch);
+                prev_sep = false;
+            }
+        }
+
+        out.trim_end_matches('-').to_string()
+    }
+
+    fn parse_dependency_name(dep_str: &str) -> Option<String> {
+        let dep_str = dep_str.trim();
+        let name_end = dep_str
+            .find(|c: char| !c.is_alphanumeric() && c != '-' && c != '_' && c != '.')
+            .unwrap_or(dep_str.len());
+
+        if name_end > 0 {
+            Some(Self::normalize_pep503(&dep_str[..name_end]))
+        } else {
+            None
+        }
+    }
+
+    fn parse_dependency_parts(dep_str: &str) -> Option<(String, String, String)> {
+        let dep_str = dep_str.trim();
+
+        let name_end = dep_str
+            .find(|c: char| !c.is_alphanumeric() && c != '-' && c != '_' && c != '.')
+            .unwrap_or(dep_str.len());
+
+        if name_end == 0 {
+            return None;
+        }
+
+        let name = &dep_str[..name_end];
+        let rest = &dep_str[name_end..];
+
+        let mut extras = String::new();
+        let mut remaining = rest.trim_start();
+
+        if remaining.starts_with('[') {
+            if let Some(close) = remaining.find(']') {
+                extras = remaining[..=close].to_string();
+                remaining = remaining[close + 1..].trim_start();
+            }
+        }
+
+        if remaining.starts_with('@') {
+            return None;
+        }
+
+        let marker_start = remaining.find(';');
+        let (version_spec, marker) = match marker_start {
+            Some(pos) => (remaining[..pos].trim(), remaining[pos..].to_string()),
+            None => (remaining.trim(), String::new()),
+        };
+
+        Some((name.to_string(), format!("{}{}", extras, marker), version_spec.to_string()))
+    }
+
+    fn dependency_matches(dep_str: &str, name: &str) -> bool {
+        if let Some(parsed_name) = Self::parse_dependency_name(dep_str) {
+            let normalized_name = Self::normalize_pep503(name);
+            parsed_name == normalized_name
+        } else {
+            false
+        }
+    }
+
+    fn rewrite_dependency(dep_str: &str, new_version: &Version) -> Option<String> {
+        let (name, extras_marker, _old_version) = Self::parse_dependency_parts(dep_str)?;
+
+        let (extras, marker) = if let Some(marker_pos) = extras_marker.find(';') {
+            (
+                extras_marker[..marker_pos].to_string(),
+                extras_marker[marker_pos..].to_string(),
+            )
+        } else {
+            (extras_marker, String::new())
+        };
+
+        Some(format!("{}{}=={}{}", name, extras, new_version, marker))
+    }
+
+    pub fn update_all_dependency_versions(
+        packages: &[Package],
+        _root: &Path,
+        updates: &HashMap<String, Version>,
+    ) -> Result<()> {
+        for package in packages {
+            for (dep_name, new_version) in updates {
+                Self::update_dependency_version(&package.manifest_path, dep_name, new_version)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn create_pyproject(dir: &Path, content: &str) -> std::path::PathBuf {
+        let path = dir.join("pyproject.toml");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn discover_valid_pyproject() {
+        let tmp = TempDir::new().unwrap();
+        create_pyproject(
+            tmp.path(),
+            r#"
+[project]
+name = "my-package"
+version = "1.2.3"
+dependencies = ["requests>=2.0"]
+"#,
+        );
+
+        let packages = PythonAdapter::discover(tmp.path()).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "my-package");
+        assert_eq!(packages[0].version.to_string(), "1.2.3");
+        assert_eq!(packages[0].dependencies, vec!["requests"]);
+    }
+
+    #[test]
+    fn discover_missing_pyproject() {
+        let tmp = TempDir::new().unwrap();
+        let result = PythonAdapter::discover(tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No pyproject.toml"));
+    }
+
+    #[test]
+    fn discover_missing_project_section() {
+        let tmp = TempDir::new().unwrap();
+        create_pyproject(
+            tmp.path(),
+            r#"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"#,
+        );
+
+        let result = PythonAdapter::discover(tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("[project]"));
+    }
+
+    #[test]
+    fn discover_dynamic_version_error() {
+        let tmp = TempDir::new().unwrap();
+        create_pyproject(
+            tmp.path(),
+            r#"
+[project]
+name = "my-package"
+dynamic = ["version"]
+"#,
+        );
+
+        let result = PythonAdapter::discover(tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Dynamic"));
+    }
+
+    #[test]
+    fn discover_missing_version() {
+        let tmp = TempDir::new().unwrap();
+        create_pyproject(
+            tmp.path(),
+            r#"
+[project]
+name = "my-package"
+"#,
+        );
+
+        let result = PythonAdapter::discover(tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("version"));
+    }
+
+    #[test]
+    fn pep503_normalization() {
+        assert_eq!(PythonAdapter::normalize_pep503("Requests"), "requests");
+        assert_eq!(PythonAdapter::normalize_pep503("my_pkg"), "my-pkg");
+        assert_eq!(PythonAdapter::normalize_pep503("my..pkg"), "my-pkg");
+        assert_eq!(PythonAdapter::normalize_pep503("my---pkg"), "my-pkg");
+        assert_eq!(PythonAdapter::normalize_pep503("My_Cool.Package"), "my-cool-package");
+        assert_eq!(PythonAdapter::normalize_pep503("pkg-"), "pkg");
+        assert_eq!(PythonAdapter::normalize_pep503("pkg_-_"), "pkg");
+    }
+
+    #[test]
+    fn parse_dependency_name_simple() {
+        assert_eq!(
+            PythonAdapter::parse_dependency_name("requests"),
+            Some("requests".to_string())
+        );
+        assert_eq!(
+            PythonAdapter::parse_dependency_name("requests>=2.0"),
+            Some("requests".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_dependency_name_with_extras() {
+        assert_eq!(
+            PythonAdapter::parse_dependency_name("requests[security]>=2.0"),
+            Some("requests".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_dependency_name_with_markers() {
+        assert_eq!(
+            PythonAdapter::parse_dependency_name("importlib-metadata; python_version<\"3.10\""),
+            Some("importlib-metadata".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_dependency_name_with_extras_and_markers() {
+        assert_eq!(
+            PythonAdapter::parse_dependency_name("foo[bar,baz]>=1.0,<2.0; python_version>=\"3.8\""),
+            Some("foo".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_dependency_name_normalized() {
+        assert_eq!(
+            PythonAdapter::parse_dependency_name("My_Package>=1.0"),
+            Some("my-package".to_string())
+        );
+    }
+
+    #[test]
+    fn read_and_write_version() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_pyproject(
+            tmp.path(),
+            r#"
+[project]
+name = "my-package"
+version = "1.0.0"
+"#,
+        );
+
+        let version = PythonAdapter::read_version(&path).unwrap();
+        assert_eq!(version.to_string(), "1.0.0");
+
+        let new_version: Version = "2.0.0".parse().unwrap();
+        PythonAdapter::write_version(&path, &new_version).unwrap();
+
+        let updated = PythonAdapter::read_version(&path).unwrap();
+        assert_eq!(updated.to_string(), "2.0.0");
+    }
+
+    #[test]
+    fn write_version_missing_project_errors() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_pyproject(
+            tmp.path(),
+            r#"
+[build-system]
+requires = ["hatchling"]
+"#,
+        );
+
+        let new_version: Version = "2.0.0".parse().unwrap();
+        let result = PythonAdapter::write_version(&path, &new_version);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_dependency_version() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_pyproject(
+            tmp.path(),
+            r#"
+[project]
+name = "my-package"
+version = "1.0.0"
+dependencies = [
+    "requests>=2.0",
+    "click>=8.0",
+]
+"#,
+        );
+
+        let new_version: Version = "3.0.0".parse().unwrap();
+        let modified =
+            PythonAdapter::update_dependency_version(&path, "requests", &new_version).unwrap();
+        assert!(modified);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("requests==3.0.0"));
+        assert!(content.contains("click>=8.0"));
+    }
+
+    #[test]
+    fn dependency_matches_normalized() {
+        assert!(PythonAdapter::dependency_matches("My_Package>=1.0", "my-package"));
+        assert!(PythonAdapter::dependency_matches("my-package>=1.0", "My_Package"));
+        assert!(!PythonAdapter::dependency_matches("other-pkg>=1.0", "my-package"));
+    }
+
+    #[test]
+    fn rewrite_dependency_preserves_extras_and_markers() {
+        let new_version: Version = "2.0.0".parse().unwrap();
+        
+        let result = PythonAdapter::rewrite_dependency("foo[bar]>=1.0", &new_version);
+        assert_eq!(result, Some("foo[bar]==2.0.0".to_string()));
+
+        let result = PythonAdapter::rewrite_dependency("foo>=1.0; python_version>=\"3.8\"", &new_version);
+        assert_eq!(result, Some("foo==2.0.0; python_version>=\"3.8\"".to_string()));
+
+        let result = PythonAdapter::rewrite_dependency("foo[bar,baz]>=1.0; os_name==\"nt\"", &new_version);
+        assert_eq!(result, Some("foo[bar,baz]==2.0.0; os_name==\"nt\"".to_string()));
+    }
+}

--- a/src/ecosystems/rust.rs
+++ b/src/ecosystems/rust.rs
@@ -1,0 +1,227 @@
+use crate::ecosystems::{Ecosystem, EcosystemAdapter, Package};
+use crate::error::Result;
+use cargo_metadata::MetadataCommand;
+use semver::Version;
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+use toml_edit::DocumentMut;
+
+pub struct RustAdapter;
+
+impl EcosystemAdapter for RustAdapter {
+    fn ecosystem() -> Ecosystem {
+        Ecosystem::Rust
+    }
+
+    fn discover(root: &Path) -> Result<Vec<Package>> {
+        let metadata = MetadataCommand::new().current_dir(root).exec()?;
+
+        let workspace_members: std::collections::HashSet<_> =
+            metadata.workspace_members.iter().collect();
+
+        let mut packages = Vec::new();
+
+        for package in &metadata.packages {
+            if !workspace_members.contains(&package.id) {
+                continue;
+            }
+
+            let deps: Vec<String> = package
+                .dependencies
+                .iter()
+                .filter_map(|dep| {
+                    metadata
+                        .packages
+                        .iter()
+                        .find(|p| p.name == dep.name && workspace_members.contains(&p.id))
+                        .map(|p| p.name.clone())
+                })
+                .collect();
+
+            packages.push(Package {
+                name: package.name.clone(),
+                version: package.version.clone(),
+                path: package
+                    .manifest_path
+                    .parent()
+                    .unwrap()
+                    .to_path_buf()
+                    .into_std_path_buf(),
+                manifest_path: package.manifest_path.clone().into_std_path_buf(),
+                dependencies: deps,
+            });
+        }
+
+        Ok(packages)
+    }
+
+    fn read_version(manifest_path: &Path) -> Result<Version> {
+        let content = std::fs::read_to_string(manifest_path)?;
+        let doc: DocumentMut = content.parse()?;
+
+        let version_str = doc["package"]["version"]
+            .as_str()
+            .ok_or_else(|| crate::error::Error::VersionNotFound(manifest_path.display().to_string()))?;
+
+        Ok(version_str.parse()?)
+    }
+
+    fn write_version(manifest_path: &Path, version: &Version) -> Result<()> {
+        let content = std::fs::read_to_string(manifest_path)?;
+        let mut doc: DocumentMut = content.parse()?;
+
+        doc["package"]["version"] = toml_edit::value(version.to_string());
+
+        std::fs::write(manifest_path, doc.to_string())?;
+        Ok(())
+    }
+
+    fn update_dependency_version(
+        manifest_path: &Path,
+        dep_name: &str,
+        new_version: &Version,
+    ) -> Result<bool> {
+        let content = std::fs::read_to_string(manifest_path)?;
+        let mut doc: DocumentMut = content.parse()?;
+        let mut modified = false;
+
+        for section in &["dependencies", "dev-dependencies", "build-dependencies"] {
+            if let Some(deps) = doc.get_mut(section) {
+                if let Some(dep) = deps.get_mut(dep_name) {
+                    if let Some(table) = dep.as_inline_table_mut() {
+                        if table.contains_key("version") {
+                            table.insert("version", new_version.to_string().into());
+                            modified = true;
+                        }
+                    } else if let Some(table) = dep.as_table_mut() {
+                        if table.contains_key("version") {
+                            table["version"] = toml_edit::value(new_version.to_string());
+                            modified = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(workspace) = doc.get_mut("workspace") {
+            if let Some(deps) = workspace.get_mut("dependencies") {
+                if let Some(dep) = deps.get_mut(dep_name) {
+                    if let Some(table) = dep.as_inline_table_mut() {
+                        if table.contains_key("version") {
+                            table.insert("version", new_version.to_string().into());
+                            modified = true;
+                        }
+                    } else if let Some(table) = dep.as_table_mut() {
+                        if table.contains_key("version") {
+                            table["version"] = toml_edit::value(new_version.to_string());
+                            modified = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if modified {
+            std::fs::write(manifest_path, doc.to_string())?;
+        }
+
+        Ok(modified)
+    }
+
+    fn is_published(name: &str, version: &Version) -> Result<bool> {
+        let output = Command::new("cargo")
+            .args(["search", "--limit", "1", name])
+            .output()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let is_published_with_same_version = stdout
+            .lines()
+            .next()
+            .map(|line| line.contains(&format!("\"{}\"", version)))
+            .unwrap_or(false);
+
+        Ok(is_published_with_same_version)
+    }
+
+    fn publish(pkg: &Package, dry_run: bool, registry: Option<&str>) -> Result<bool> {
+        if dry_run {
+            return Ok(true);
+        }
+
+        let mut cmd = Command::new("cargo");
+        cmd.arg("publish")
+            .arg("--package")
+            .arg(&pkg.name)
+            .arg("--no-verify")
+            .arg("--allow-dirty");
+
+        if let Some(reg) = registry {
+            cmd.env("CARGO_REGISTRY_DEFAULT", reg);
+        }
+
+        let output = cmd.output()?;
+
+        if output.status.success() {
+            return Ok(true);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("already uploaded") || stderr.contains("already exists") {
+            return Ok(true);
+        }
+
+        Err(crate::error::Error::PublishFailed(format!(
+            "cargo publish failed: {}",
+            stderr
+        )))
+    }
+}
+
+impl RustAdapter {
+    pub fn update_all_dependency_versions(
+        packages: &[Package],
+        root: &Path,
+        updates: &HashMap<String, Version>,
+    ) -> Result<()> {
+        for package in packages {
+            for (dep_name, new_version) in updates {
+                Self::update_dependency_version(&package.manifest_path, dep_name, new_version)?;
+            }
+        }
+
+        let root_manifest = root.join("Cargo.toml");
+        if root_manifest.exists() {
+            let content = std::fs::read_to_string(&root_manifest)?;
+            let mut doc: DocumentMut = content.parse()?;
+            let mut modified = false;
+
+            if let Some(workspace) = doc.get_mut("workspace") {
+                if let Some(deps) = workspace.get_mut("dependencies") {
+                    for (dep_name, new_version) in updates {
+                        if let Some(dep) = deps.get_mut(dep_name) {
+                            if let Some(table) = dep.as_inline_table_mut() {
+                                if table.contains_key("version") {
+                                    table.insert("version", new_version.to_string().into());
+                                    modified = true;
+                                }
+                            } else if let Some(table) = dep.as_table_mut() {
+                                if table.contains_key("version") {
+                                    table["version"] = toml_edit::value(new_version.to_string());
+                                    modified = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if modified {
+                std::fs::write(&root_manifest, doc.to_string())?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("not in a Cargo workspace")]
+    #[error("not in a workspace")]
     NotInWorkspace,
 
     #[error("changelogs already initialized")]
@@ -13,6 +13,9 @@ pub enum Error {
 
     #[error("invalid bump type: {0}")]
     InvalidBumpType(String),
+
+    #[error("invalid ecosystem: {0}")]
+    InvalidEcosystem(String),
 
     #[error("package not found: {0}")]
     PackageNotFound(String),
@@ -25,6 +28,24 @@ pub enum Error {
 
     #[error("no packages selected")]
     NoPackagesSelected,
+
+    #[error("version not found in {0}")]
+    VersionNotFound(String),
+
+    #[error("failed to parse version: {0}")]
+    VersionParse(String),
+
+    #[error("Python project not found: {0}")]
+    PythonProjectNotFound(String),
+
+    #[error("Python dynamic version: {0}")]
+    PythonDynamicVersion(String),
+
+    #[error("publish failed: {0}")]
+    PublishFailed(String),
+
+    #[error("failed to check PyPI: {0}")]
+    PypiCheckFailed(String),
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
@@ -40,6 +61,9 @@ pub enum Error {
 
     #[error("cargo metadata error: {0}")]
     CargoMetadata(#[from] cargo_metadata::Error),
+
+    #[error("semver parse error: {0}")]
+    SemverParse(#[from] semver::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod changelog_entry;
 pub mod changelog_writer;
 pub mod config;
+pub mod ecosystems;
 pub mod error;
 pub mod graph;
 pub mod plan;
@@ -10,8 +11,9 @@ use serde::{Deserialize, Serialize};
 
 pub use changelog_entry::{Changelog, Release};
 pub use config::Config;
+pub use ecosystems::{Ecosystem, Package};
 pub use plan::{PackageRelease, ReleasePlan};
-pub use workspace::{Workspace, WorkspacePackage as Package};
+pub use workspace::Workspace;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 use anyhow::Result;
+use changelogs::Ecosystem;
 use clap::{Parser, Subcommand};
 
 mod cli;
 
 #[derive(Parser)]
 #[command(name = "changelogs")]
-#[command(about = "Manage versioning and changelogs for Cargo workspaces")]
+#[command(about = "Manage versioning and changelogs for workspaces")]
 #[command(version)]
 struct Cli {
+    /// Ecosystem to use (rust, python). Auto-detected if not specified.
+    #[arg(long, global = true)]
+    ecosystem: Option<Ecosystem>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -62,11 +67,11 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init => cli::init::run()?,
-        Commands::Add { empty, ai, instructions, base_ref } => cli::add::run(empty, ai, instructions, base_ref)?,
-        Commands::Status { verbose } => cli::status::run(verbose)?,
-        Commands::Version => cli::version::run()?,
-        Commands::Publish { dry_run, tag } => cli::publish::run(dry_run, tag)?,
+        Commands::Init => cli::init::run(cli.ecosystem)?,
+        Commands::Add { empty, ai, instructions, base_ref } => cli::add::run(empty, ai, instructions, base_ref, cli.ecosystem)?,
+        Commands::Status { verbose } => cli::status::run(verbose, cli.ecosystem)?,
+        Commands::Version => cli::version::run(cli.ecosystem)?,
+        Commands::Publish { dry_run, tag } => cli::publish::run_with_ecosystem(dry_run, tag, cli.ecosystem)?,
     }
 
     Ok(())

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -154,8 +154,8 @@ mod tests {
     use crate::Release;
     use semver::Version;
 
-    fn mock_package(name: &str, version: &str, deps: Vec<&str>) -> crate::workspace::WorkspacePackage {
-        crate::workspace::WorkspacePackage {
+    fn mock_package(name: &str, version: &str, deps: Vec<&str>) -> crate::ecosystems::Package {
+        crate::ecosystems::Package {
             name: name.to_string(),
             version: Version::parse(version).unwrap(),
             path: std::path::PathBuf::from(format!("crates/{}", name)),

--- a/tests/fixtures/python-simple/pyproject.toml
+++ b/tests/fixtures/python-simple/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "my-package"
+version = "0.1.0"
+description = "A test Python package"
+requires-python = ">=3.8"
+dependencies = [
+    "requests>=2.28.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tests/fixtures/python-simple/src/my_package/__init__.py
+++ b/tests/fixtures/python-simple/src/my_package/__init__.py
@@ -1,0 +1,3 @@
+"""My test package."""
+
+__version__ = "0.1.0"

--- a/tests/python_adapter.rs
+++ b/tests/python_adapter.rs
@@ -1,0 +1,267 @@
+use changelogs::ecosystems::{Ecosystem, EcosystemAdapter, PythonAdapter};
+use semver::Version;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn create_pyproject(dir: &std::path::Path, content: &str) {
+    std::fs::write(dir.join("pyproject.toml"), content).unwrap();
+}
+
+#[test]
+fn test_python_discover() {
+    let root = fixture_path("python-simple");
+    let packages = PythonAdapter::discover(&root).unwrap();
+
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name, "my-package");
+    assert_eq!(packages[0].version, Version::new(0, 1, 0));
+    assert!(packages[0].manifest_path.ends_with("pyproject.toml"));
+}
+
+#[test]
+fn test_python_read_version() {
+    let root = fixture_path("python-simple");
+    let manifest_path = root.join("pyproject.toml");
+    
+    let version = PythonAdapter::read_version(&manifest_path).unwrap();
+    assert_eq!(version, Version::new(0, 1, 0));
+}
+
+#[test]
+fn test_python_write_version() {
+    let temp_dir = TempDir::new().unwrap();
+    let pyproject_path = temp_dir.path().join("pyproject.toml");
+    
+    let original_content = r#"[project]
+name = "test-package"
+version = "1.0.0"
+description = "Test"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"#;
+    std::fs::write(&pyproject_path, original_content).unwrap();
+    
+    let new_version = Version::new(2, 0, 0);
+    PythonAdapter::write_version(&pyproject_path, &new_version).unwrap();
+    
+    let updated_content = std::fs::read_to_string(&pyproject_path).unwrap();
+    assert!(updated_content.contains("version = \"2.0.0\""));
+    assert!(updated_content.contains("name = \"test-package\""));
+    assert!(updated_content.contains("[build-system]"));
+}
+
+#[test]
+fn test_python_discover_rejects_dynamic_version() {
+    let temp_dir = TempDir::new().unwrap();
+    let pyproject_path = temp_dir.path().join("pyproject.toml");
+    
+    let content = r#"[project]
+name = "dynamic-package"
+dynamic = ["version"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"#;
+    std::fs::write(&pyproject_path, content).unwrap();
+    
+    let result = PythonAdapter::discover(temp_dir.path());
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("Dynamic versions"));
+}
+
+#[test]
+fn test_python_discover_requires_project_section() {
+    let temp_dir = TempDir::new().unwrap();
+    let pyproject_path = temp_dir.path().join("pyproject.toml");
+    
+    let content = r#"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"#;
+    std::fs::write(&pyproject_path, content).unwrap();
+    
+    let result = PythonAdapter::discover(temp_dir.path());
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("[project]"));
+}
+
+#[test]
+fn test_ecosystem_detection() {
+    let rust_dir = TempDir::new().unwrap();
+    std::fs::write(rust_dir.path().join("Cargo.toml"), "[package]").unwrap();
+    
+    let python_dir = TempDir::new().unwrap();
+    std::fs::write(python_dir.path().join("pyproject.toml"), "[project]").unwrap();
+    
+    let empty_dir = TempDir::new().unwrap();
+    
+    assert_eq!(
+        changelogs::ecosystems::detect_ecosystem(rust_dir.path()),
+        Some(Ecosystem::Rust)
+    );
+    assert_eq!(
+        changelogs::ecosystems::detect_ecosystem(python_dir.path()),
+        Some(Ecosystem::Python)
+    );
+    assert_eq!(
+        changelogs::ecosystems::detect_ecosystem(empty_dir.path()),
+        None
+    );
+}
+
+#[test]
+fn test_ecosystem_detection_from_subdirectory() {
+    let temp_dir = TempDir::new().unwrap();
+    let subdir = temp_dir.path().join("src").join("nested");
+    std::fs::create_dir_all(&subdir).unwrap();
+
+    create_pyproject(
+        temp_dir.path(),
+        r#"[project]
+name = "parent-pkg"
+version = "1.0.0"
+"#,
+    );
+
+    assert_eq!(
+        changelogs::ecosystems::detect_ecosystem(&subdir),
+        Some(Ecosystem::Python)
+    );
+}
+
+#[test]
+fn test_update_dependency_preserves_extras() {
+    let temp_dir = TempDir::new().unwrap();
+    create_pyproject(
+        temp_dir.path(),
+        r#"[project]
+name = "test-pkg"
+version = "1.0.0"
+dependencies = [
+    "requests[socks]>=2.0",
+]
+"#,
+    );
+
+    let manifest_path = temp_dir.path().join("pyproject.toml");
+    let new_version = Version::new(3, 0, 0);
+    let modified =
+        PythonAdapter::update_dependency_version(&manifest_path, "requests", &new_version)
+            .unwrap();
+
+    assert!(modified);
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    assert!(content.contains("requests[socks]==3.0.0"));
+}
+
+#[test]
+fn test_update_dependency_preserves_markers() {
+    let temp_dir = TempDir::new().unwrap();
+    create_pyproject(
+        temp_dir.path(),
+        r#"[project]
+name = "test-pkg"
+version = "1.0.0"
+dependencies = [
+    "typing-extensions>=4.0; python_version < '3.11'",
+]
+"#,
+    );
+
+    let manifest_path = temp_dir.path().join("pyproject.toml");
+    let new_version = Version::new(5, 0, 0);
+    let modified =
+        PythonAdapter::update_dependency_version(&manifest_path, "typing-extensions", &new_version)
+            .unwrap();
+
+    assert!(modified);
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    assert!(content.contains("typing-extensions==5.0.0; python_version < '3.11'"));
+}
+
+#[test]
+fn test_update_dependency_preserves_extras_and_markers() {
+    let temp_dir = TempDir::new().unwrap();
+    create_pyproject(
+        temp_dir.path(),
+        r#"[project]
+name = "test-pkg"
+version = "1.0.0"
+dependencies = [
+    "httpx[http2]>=0.20; sys_platform != 'win32'",
+]
+"#,
+    );
+
+    let manifest_path = temp_dir.path().join("pyproject.toml");
+    let new_version = Version::new(1, 0, 0);
+    let modified =
+        PythonAdapter::update_dependency_version(&manifest_path, "httpx", &new_version).unwrap();
+
+    assert!(modified);
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    assert!(content.contains("httpx[http2]==1.0.0; sys_platform != 'win32'"));
+}
+
+#[test]
+fn test_pep503_name_normalization() {
+    let temp_dir = TempDir::new().unwrap();
+    create_pyproject(
+        temp_dir.path(),
+        r#"[project]
+name = "test-pkg"
+version = "1.0.0"
+dependencies = [
+    "Foo_Bar>=1.0",
+    "foo.baz>=2.0",
+    "foo---qux>=3.0",
+]
+"#,
+    );
+
+    let packages = PythonAdapter::discover(temp_dir.path()).unwrap();
+    let deps = &packages[0].dependencies;
+
+    assert!(deps.contains(&"foo-bar".to_string()));
+    assert!(deps.contains(&"foo-baz".to_string()));
+    assert!(deps.contains(&"foo-qux".to_string()));
+}
+
+#[test]
+fn test_update_dependency_in_optional_deps() {
+    let temp_dir = TempDir::new().unwrap();
+    create_pyproject(
+        temp_dir.path(),
+        r#"[project]
+name = "test-pkg"
+version = "1.0.0"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest[cov]>=7.0",
+]
+"#,
+    );
+
+    let manifest_path = temp_dir.path().join("pyproject.toml");
+    let new_version = Version::new(8, 0, 0);
+    let modified =
+        PythonAdapter::update_dependency_version(&manifest_path, "pytest", &new_version).unwrap();
+
+    assert!(modified);
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    assert!(content.contains("pytest[cov]==8.0.0"));
+}


### PR DESCRIPTION
- Add EcosystemAdapter trait abstraction for multi-language support
- Extract existing Cargo/Rust logic into RustAdapter
- Implement PythonAdapter for PEP 621 pyproject.toml packages
- Support static versions only (dynamic versions produce clear error)
- Publishing via python -m build + twine upload
- TestPyPI and custom registry support
- PEP 503 name normalization for dependency matching
- Comprehensive test coverage (33 tests)

Python adapter constraints:
- Requires [project] section with static version field
- Uses toml_edit for format-preserving edits
- Dependency version updates preserve extras and markers

Security improvements:
- Path canonicalization before dist/ deletion
- No shell command interpolation
- Registry parameter properly escaped