### PR TITLE
refactor: simplify ecosystem adapter code with helpers and aliases

### DIFF
--- a/src/ecosystems/mod.rs
+++ b/src/ecosystems/mod.rs
@@ -18,6 +18,22 @@ pub enum Ecosystem {
     Python,
 }
 
+impl Ecosystem {
+    const RUST_ALIASES: &[&str] = &["rust", "cargo"];
+    const PYTHON_ALIASES: &[&str] = &["python", "pypi"];
+
+    pub fn from_alias(s: &str) -> Option<Self> {
+        let lower = s.to_lowercase();
+        if Self::RUST_ALIASES.contains(&lower.as_str()) {
+            Some(Ecosystem::Rust)
+        } else if Self::PYTHON_ALIASES.contains(&lower.as_str()) {
+            Some(Ecosystem::Python)
+        } else {
+            None
+        }
+    }
+}
+
 impl std::fmt::Display for Ecosystem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -31,11 +47,7 @@ impl std::str::FromStr for Ecosystem {
     type Err = crate::error::Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "rust" | "cargo" => Ok(Ecosystem::Rust),
-            "python" | "pypi" => Ok(Ecosystem::Python),
-            _ => Err(crate::error::Error::InvalidEcosystem(s.to_string())),
-        }
+        Self::from_alias(s).ok_or_else(|| crate::error::Error::InvalidEcosystem(s.to_string()))
     }
 }
 


### PR DESCRIPTION
## Summary

Refactoring improvements to the Python ecosystem support added in #15

## Changes

### Ecosystem Aliases (`src/ecosystems/mod.rs`)
- Extract ecosystem string lookups into const arrays (`RUST_ALIASES`, `PYTHON_ALIASES`)
- Add `Ecosystem::from_alias()` method for cleaner parsing
- Simplify `FromStr` implementation to use the new method

### Python Adapter (`src/ecosystems/python.rs`)
- Extract `update_deps_in_array()` helper to reduce nesting in `update_dependency_version`
- Use let-else pattern for early returns
- Flatten nested if-let chains with `.and_then()`

### Rust Adapter (`src/ecosystems/rust.rs`)
- Extract `update_dep_version_in_item()` helper for inline/regular table version updates
- Simplify `update_dependency_version` with let-else and chained `.and_then()`
- Simplify `update_all_dependency_versions` with early return pattern