### PR TITLE
fix: include full changelogs ASCII banner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,13 @@ BANNER='
          ,,                                               ,,
        `7MM                                             `7MM
          MM                                               MM
- ,p6"bo  MMpMMMb.   ,6"Yb.  `7MMpMMMb.  .P"Ybmmm .gP"Ya   MM  ,pW"Wq.
-6M'"'"'  OO  MM    MM  8)   MM    MM    MM :MI  I8  ,M'"'"'   Yb  MM 6W'"'"'   `Wb
-8M       MM    MM   ,pm9MM    MM    MM  WmmmP"  8M""""""  MM 8M     M8
-YM.    , MM    MM  8M   MM    MM    MM 8M       YM.    ,  MM YA.   ,A9
- YMbmd'"'"'.JMML  JMML.`Moo9^Yo..JMML  JMML.YMMMMMb  `Mbmmd'"'"'.JMML.`Ybmd9'"'"'
-                                       6'"'"'     dP
-                                       Ybmmmd'"'"'
+ ,p6"bo  MMpMMMb.   ,6"Yb.  `7MMpMMMb.  .P"Ybmmm .gP"Ya   MM  ,pW"Wq.   .P"Ybmmm ,pP"Ybd
+6M'"'"'  OO  MM    MM  8)   MM    MM    MM :MI  I8  ,M'"'"'   Yb  MM 6W'"'"'   `Wb :MI  I8   8I   `"
+8M       MM    MM   ,pm9MM    MM    MM  WmmmP"  8M""""""  MM 8M     M8  WmmmP"   `YMMMa.
+YM.    , MM    MM  8M   MM    MM    MM 8M       YM.    ,  MM YA.   ,A9 8M        L.   I8
+ YMbmd'"'"'.JMML  JMML.`Moo9^Yo..JMML  JMML.YMMMMMb  `Mbmmd'"'"'.JMML.`Ybmd9'"'"'  YMMMMMb  M9mmmP'"'"'
+                                       6'"'"'     dP                   6'"'"'     dP
+                                       Ybmmmd'"'"'                    Ybmmmd'"'"'
 '
 
 echo "$BANNER"


### PR DESCRIPTION
The Georgia11 ASCII banner was missing the 'gs' suffix because the font wraps on long words. This fixes it by appending the wrapped portion to each line.

Before:
```
 ,p6"bo  MMpMMMb.   ,6"Yb.  `7MMpMMMb.  .P"Ybmmm .gP"Ya   MM  ,pW"Wq.
```

After:
```
 ,p6"bo  MMpMMMb.   ,6"Yb.  `7MMpMMMb.  .P"Ybmmm .gP"Ya   MM  ,pW"Wq.   .P"Ybmmm ,pP"Ybd
```

Now shows the full word "changelogs" instead of just "changelog".

```
~/tempo/changelogs-rs (fix/ascii-banner ✔) sh install.sh                                                                                             [1]

         ,,                                               ,,
       `7MM                                             `7MM
         MM                                               MM
 ,p6"bo  MMpMMMb.   ,6"Yb.  `7MMpMMMb.  .P"Ybmmm .gP"Ya   MM  ,pW"Wq.   .P"Ybmmm ,pP"Ybd
6M'  OO  MM    MM  8)   MM    MM    MM :MI  I8  ,M'   Yb  MM 6W'   `Wb :MI  I8   8I   `"
8M       MM    MM   ,pm9MM    MM    MM  WmmmP"  8M""""""  MM 8M     M8  WmmmP"   `YMMMa.
YM.    , MM    MM  8M   MM    MM    MM 8M       YM.    ,  MM YA.   ,A9 8M        L.   I8
 YMbmd'.JMML  JMML.`Moo9^Yo..JMML  JMML.YMMMMMb  `Mbmmd'.JMML.`Ybmd9'  YMMMMMb  M9mmmP'
                                       6'     dP                   6'     dP
                                       Ybmmmd'                    Ybmmmd'

Detected: darwin/arm64
Installing changelogs latest...
Downloading from https://github.com/wevm/changelogs-rs/releases/download/latest/changelogs-darwin-arm64...

Installed changelogs to /Users/brendanryan/.local/bin/changelogs
```