### PR TITLE
fix(gen): improve error message for missing AI API keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "changelogs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
When using the `gen/action.yml` action with AI providers and the required API key is missing or invalid, the error was cryptic (e.g., `Invalid API key`).

This PR detects API key errors and provides helpful guidance:

- Identifies the specific provider (amp, claude, openai, gemini)
- Shows the required environment variable name
- Provides example GitHub Actions workflow syntax
- Reminds users to configure secrets in repository settings

**Example improved error:**
```
AI command failed: API key is missing or invalid.

Hint: The 'claude' command requires ANTHROPIC_API_KEY to be set.
In GitHub Actions, add this to your workflow:
  env:
    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

Make sure the ANTHROPIC_API_KEY secret is configured in your repository settings.

Original error:
Invalid API key
```

This helps users quickly diagnose and fix the common issue of forgetting to set up secrets when using AI changelog generation.