### PR TITLE
fix: find first merge commit instead of most recent for PR detection

### DIFF
--- a/.changelog/shy-bats-wave.md
+++ b/.changelog/shy-bats-wave.md
@@ -2,4 +2,4 @@
 changelogs: patch
 ---
 
-Fixed PR number detection to use merge commit instead of file creation commit.
+Fixed PR number detection to find the *first* merge commit that brought a changelog file into the branch, rather than the most recent one. This prevents incorrect PR attribution on release branches where later merges could incorrectly claim authorship.


### PR DESCRIPTION
## Problem

The previous implementation used `git log --merges --ancestry-path -1` which finds the **most recent** merge commit that touched the changelog file. On release branches, this could incorrectly attribute changes to the release PR itself or subsequent fix PRs.

## Solution

Refactored `get_commit_info` to:

1. First find the commit that originally added the changelog file (`find_add_commit`)
2. Use `git log --merges --ancestry-path --reverse {add_commit}..HEAD` to find merge commits from oldest to newest
3. Take the **first** (oldest) merge commit as the one that originally brought the change into the branch
4. Fall back to the add commit itself if no merge commits exist (direct pushes)

This ensures correct PR attribution regardless of subsequent merges to the branch.