### PR TITLE
fix: add cache with version-pinned key for changelogs binary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,9 +60,17 @@ runs:
       shell: bash
       run: pip install build twine
 
+    - name: Cache changelogs binary
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/changelogs
+        key: changelogs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.toml') }}
+
     - name: Install changelogs
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      run: curl -sSL https://changelogs.sh | sh
+      run: cargo install changelogs
 
     - name: Check for changelogs
       id: check


### PR DESCRIPTION
Adds version pinning via an opaque to the changelogs binary cache key in action.yml. 

Without this, the cache never busts when changelogs is updated, causing stale binaries to be used. Even if upstream is bumped