### PR TITLE
fix: remove eval in check action

### DIFF
--- a/check/action.yml
+++ b/check/action.yml
@@ -50,12 +50,13 @@ runs:
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         
-        # Run changelogs add with AI, capture the generated file
-        ARGS="--ai \"${{ inputs.ai }}\" --ref origin/${{ inputs.ref }}"
+        # Run changelogs add with AI
+        CMD=(changelogs)
         if [ -n "${{ inputs.ecosystem }}" ]; then
-          ARGS="$ARGS --ecosystem \"${{ inputs.ecosystem }}\""
+          CMD+=(--ecosystem "${{ inputs.ecosystem }}")
         fi
-        eval "changelogs add $ARGS"
+        CMD+=(add --ai "${{ inputs.ai }}" --ref "origin/${{ inputs.ref }}")
+        "${CMD[@]}"
         
         # Find the generated changelog file
         GENERATED_FILE=$(ls -t .changelog/*.md | grep -v README.md | head -n1)


### PR DESCRIPTION
Replaces the `eval "changelogs add $ARGS"` pattern in check/action.yml with bash array-based command construction. This avoids shell injection risks and fragility from eval-based argument expansion.