### PR TITLE
tests: add comprehensive unit tests for critical coverage gaps

### DIFF
--- a/src/changelog_writer.rs
+++ b/src/changelog_writer.rs
@@ -177,6 +177,255 @@ pub fn update_changelog(path: &Path, new_entry: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_update_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        std::fs::write(&path, "").unwrap();
+
+        update_changelog(&path, "## 1.0.0\n\n- Initial release\n\n").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "# Changelog\n\n## 1.0.0\n\n- Initial release\n\n");
+    }
+
+    #[test]
+    fn test_update_nonexistent_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+
+        update_changelog(&path, "## 1.0.0\n\n- First\n\n").unwrap();
+
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "# Changelog\n\n## 1.0.0\n\n- First\n\n");
+    }
+
+    #[test]
+    fn test_update_with_existing_header() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        std::fs::write(&path, "# Changelog\n\nold content\n").unwrap();
+
+        update_changelog(&path, "## 2.0.0\n\n- New stuff\n\n").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content,
+            "# Changelog\n\n## 2.0.0\n\n- New stuff\n\nold content\n"
+        );
+    }
+
+    #[test]
+    fn test_update_without_header() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        std::fs::write(&path, "some existing content\n").unwrap();
+
+        update_changelog(&path, "## 1.0.0\n\n- Entry\n\n").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content,
+            "# Changelog\n\n## 1.0.0\n\n- Entry\n\nsome existing content\n"
+        );
+    }
+
+    #[test]
+    fn test_multiple_sequential_updates() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+
+        update_changelog(&path, "## 1.0.0\n\n- First release\n\n").unwrap();
+        update_changelog(&path, "## 2.0.0\n\n- Second release\n\n").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content,
+            "# Changelog\n\n## 2.0.0\n\n- Second release\n\n## 1.0.0\n\n- First release\n\n"
+        );
+    }
+
+    use crate::changelog_entry::{Changelog, Release};
+    use crate::plan::PackageRelease;
+    use crate::BumpType;
+    use semver::Version;
+
+    #[test]
+    fn test_generate_entry_single_patch() {
+        let dir = TempDir::new().unwrap();
+        let release = PackageRelease {
+            name: "foo".to_string(),
+            bump: BumpType::Patch,
+            old_version: Version::new(1, 0, 0),
+            new_version: Version::new(1, 0, 1),
+            changelog_ids: vec!["change-1".to_string()],
+        };
+        let changelogs = vec![Changelog {
+            id: "change-1".to_string(),
+            summary: "fix a bug".to_string(),
+            releases: vec![Release {
+                package: "foo".to_string(),
+                bump: BumpType::Patch,
+            }],
+            commit: None,
+        }];
+
+        let output = generate_entry(&release, &changelogs, dir.path());
+
+        assert!(output.contains("## 1.0.1 ("));
+        assert!(output.contains("### Patch Changes"));
+        assert!(output.contains("fix a bug"));
+    }
+
+    #[test]
+    fn test_generate_entry_multiple_bump_types() {
+        let dir = TempDir::new().unwrap();
+        let release = PackageRelease {
+            name: "foo".to_string(),
+            bump: BumpType::Major,
+            old_version: Version::new(1, 0, 0),
+            new_version: Version::new(2, 0, 0),
+            changelog_ids: vec![
+                "c-major".to_string(),
+                "c-minor".to_string(),
+                "c-patch".to_string(),
+            ],
+        };
+        let changelogs = vec![
+            Changelog {
+                id: "c-major".to_string(),
+                summary: "breaking api change".to_string(),
+                releases: vec![Release {
+                    package: "foo".to_string(),
+                    bump: BumpType::Major,
+                }],
+                commit: None,
+            },
+            Changelog {
+                id: "c-minor".to_string(),
+                summary: "new feature".to_string(),
+                releases: vec![Release {
+                    package: "foo".to_string(),
+                    bump: BumpType::Minor,
+                }],
+                commit: None,
+            },
+            Changelog {
+                id: "c-patch".to_string(),
+                summary: "small fix".to_string(),
+                releases: vec![Release {
+                    package: "foo".to_string(),
+                    bump: BumpType::Patch,
+                }],
+                commit: None,
+            },
+        ];
+
+        let output = generate_entry(&release, &changelogs, dir.path());
+
+        assert!(output.contains("### Major Changes"));
+        assert!(output.contains("### Minor Changes"));
+        assert!(output.contains("### Patch Changes"));
+        assert!(output.contains("breaking api change"));
+        assert!(output.contains("new feature"));
+        assert!(output.contains("small fix"));
+
+        let major_pos = output.find("### Major Changes").unwrap();
+        let minor_pos = output.find("### Minor Changes").unwrap();
+        let patch_pos = output.find("### Patch Changes").unwrap();
+        assert!(major_pos < minor_pos);
+        assert!(minor_pos < patch_pos);
+    }
+
+    #[test]
+    fn test_generate_entry_only_major() {
+        let dir = TempDir::new().unwrap();
+        let release = PackageRelease {
+            name: "foo".to_string(),
+            bump: BumpType::Major,
+            old_version: Version::new(1, 0, 0),
+            new_version: Version::new(2, 0, 0),
+            changelog_ids: vec!["c-1".to_string()],
+        };
+        let changelogs = vec![Changelog {
+            id: "c-1".to_string(),
+            summary: "removed old api".to_string(),
+            releases: vec![Release {
+                package: "foo".to_string(),
+                bump: BumpType::Major,
+            }],
+            commit: None,
+        }];
+
+        let output = generate_entry(&release, &changelogs, dir.path());
+
+        assert!(output.contains("### Major Changes"));
+        assert!(!output.contains("### Minor Changes"));
+        assert!(!output.contains("### Patch Changes"));
+    }
+
+    #[test]
+    fn test_generate_entry_multiline_summary() {
+        let dir = TempDir::new().unwrap();
+        let release = PackageRelease {
+            name: "foo".to_string(),
+            bump: BumpType::Minor,
+            old_version: Version::new(1, 0, 0),
+            new_version: Version::new(1, 1, 0),
+            changelog_ids: vec!["c-1".to_string()],
+        };
+        let changelogs = vec![Changelog {
+            id: "c-1".to_string(),
+            summary: "added new feature\nwith detailed explanation\nand examples".to_string(),
+            releases: vec![Release {
+                package: "foo".to_string(),
+                bump: BumpType::Minor,
+            }],
+            commit: None,
+        }];
+
+        let output = generate_entry(&release, &changelogs, dir.path());
+
+        assert!(output.contains("added new feature"));
+        assert!(output.contains("with detailed explanation"));
+        assert!(output.contains("and examples"));
+    }
+
+    #[test]
+    fn test_generate_entry_no_matching_changelogs() {
+        let dir = TempDir::new().unwrap();
+        let release = PackageRelease {
+            name: "foo".to_string(),
+            bump: BumpType::Patch,
+            old_version: Version::new(1, 0, 0),
+            new_version: Version::new(1, 0, 1),
+            changelog_ids: vec!["nonexistent".to_string()],
+        };
+        let changelogs = vec![Changelog {
+            id: "other-change".to_string(),
+            summary: "unrelated change".to_string(),
+            releases: vec![Release {
+                package: "foo".to_string(),
+                bump: BumpType::Patch,
+            }],
+            commit: None,
+        }];
+
+        let output = generate_entry(&release, &changelogs, dir.path());
+
+        assert!(output.contains("## 1.0.1 ("));
+        assert!(!output.contains("### Major Changes"));
+        assert!(!output.contains("### Minor Changes"));
+        assert!(!output.contains("### Patch Changes"));
+    }
+}
+
 pub fn write_changelogs(
     workspace: &Workspace,
     releases: &[PackageRelease],

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -108,4 +108,126 @@ mod tests {
         assert!(dependents.contains(&"b".to_string()));
         assert!(dependents.contains(&"c".to_string()));
     }
+
+    #[test]
+    fn test_all_dependents_transitive_chain() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node("a".to_string());
+        let b = graph.add_node("b".to_string());
+        let c = graph.add_node("c".to_string());
+
+        graph.add_edge(b, a, ());
+        graph.add_edge(c, b, ());
+
+        let mut node_indices = HashMap::new();
+        node_indices.insert("a".to_string(), a);
+        node_indices.insert("b".to_string(), b);
+        node_indices.insert("c".to_string(), c);
+
+        let dep_graph = DependencyGraph {
+            graph,
+            node_indices,
+        };
+
+        let all = dep_graph.all_dependents("a");
+        assert_eq!(all.len(), 2);
+        assert!(all.contains(&"b".to_string()));
+        assert!(all.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn test_all_dependents_diamond() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node("a".to_string());
+        let b = graph.add_node("b".to_string());
+        let c = graph.add_node("c".to_string());
+        let d = graph.add_node("d".to_string());
+
+        graph.add_edge(b, a, ());
+        graph.add_edge(c, a, ());
+        graph.add_edge(d, b, ());
+        graph.add_edge(d, c, ());
+
+        let mut node_indices = HashMap::new();
+        node_indices.insert("a".to_string(), a);
+        node_indices.insert("b".to_string(), b);
+        node_indices.insert("c".to_string(), c);
+        node_indices.insert("d".to_string(), d);
+
+        let dep_graph = DependencyGraph {
+            graph,
+            node_indices,
+        };
+
+        let all = dep_graph.all_dependents("a");
+        assert_eq!(all.len(), 3);
+        assert!(all.contains(&"b".to_string()));
+        assert!(all.contains(&"c".to_string()));
+        assert!(all.contains(&"d".to_string()));
+    }
+
+    #[test]
+    fn test_dependencies() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node("a".to_string());
+        let b = graph.add_node("b".to_string());
+        let c = graph.add_node("c".to_string());
+
+        graph.add_edge(b, a, ());
+        graph.add_edge(c, a, ());
+
+        let mut node_indices = HashMap::new();
+        node_indices.insert("a".to_string(), a);
+        node_indices.insert("b".to_string(), b);
+        node_indices.insert("c".to_string(), c);
+
+        let dep_graph = DependencyGraph {
+            graph,
+            node_indices,
+        };
+
+        let deps = dep_graph.dependencies("b");
+        assert_eq!(deps, vec!["a".to_string()]);
+
+        let deps = dep_graph.dependencies("a");
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_nonexistent_package() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node("a".to_string());
+
+        let mut node_indices = HashMap::new();
+        node_indices.insert("a".to_string(), a);
+
+        let dep_graph = DependencyGraph {
+            graph,
+            node_indices,
+        };
+
+        assert!(dep_graph.dependents("nonexistent").is_empty());
+        assert!(dep_graph.all_dependents("nonexistent").is_empty());
+        assert!(dep_graph.dependencies("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn test_no_dependents() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node("a".to_string());
+        let b = graph.add_node("b".to_string());
+
+        graph.add_edge(b, a, ());
+
+        let mut node_indices = HashMap::new();
+        node_indices.insert("a".to_string(), a);
+        node_indices.insert("b".to_string(), b);
+
+        let dep_graph = DependencyGraph {
+            graph,
+            node_indices,
+        };
+
+        assert!(dep_graph.dependents("b").is_empty());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,25 @@ impl std::str::FromStr for BumpType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_bump_type_from_str_valid() {
+        assert_eq!(BumpType::from_str("patch").unwrap(), BumpType::Patch);
+        assert_eq!(BumpType::from_str("minor").unwrap(), BumpType::Minor);
+        assert_eq!(BumpType::from_str("major").unwrap(), BumpType::Major);
+        assert_eq!(BumpType::from_str("Patch").unwrap(), BumpType::Patch);
+        assert_eq!(BumpType::from_str("MAJOR").unwrap(), BumpType::Major);
+    }
+
+    #[test]
+    fn test_bump_type_from_str_invalid() {
+        assert!(BumpType::from_str("invalid").is_err());
+        assert!(BumpType::from_str("").is_err());
+        assert!(BumpType::from_str("micro").is_err());
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -154,3 +154,137 @@ impl Workspace {
         ecosystems::tag_name(self.ecosystem, pkg)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ecosystems::Package;
+    use tempfile::TempDir;
+
+    fn make_package(name: &str) -> Package {
+        Package {
+            name: name.to_string(),
+            version: Version::new(1, 0, 0),
+            path: PathBuf::from(format!("/fake/{name}")),
+            manifest_path: PathBuf::from(format!("/fake/{name}/Cargo.toml")),
+            dependencies: vec![],
+        }
+    }
+
+    fn make_workspace(root: PathBuf, packages: Vec<Package>) -> Workspace {
+        let changelog_dir = root.join(".changelog");
+        Workspace {
+            root,
+            changelog_dir,
+            packages,
+            ecosystem: Ecosystem::Rust,
+        }
+    }
+
+    #[test]
+    fn test_get_package() {
+        let ws = make_workspace(
+            PathBuf::from("/tmp/proj"),
+            vec![make_package("foo"), make_package("bar")],
+        );
+
+        let pkg = ws.get_package("foo").unwrap();
+        assert_eq!(pkg.name, "foo");
+
+        assert!(ws.get_package("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_package_names() {
+        let ws = make_workspace(
+            PathBuf::from("/tmp/proj"),
+            vec![
+                make_package("alpha"),
+                make_package("beta"),
+                make_package("gamma"),
+            ],
+        );
+
+        let names = ws.package_names();
+        assert_eq!(names, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn test_is_initialized_true() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join(".changelog")).unwrap();
+        let ws = make_workspace(dir.path().to_path_buf(), vec![]);
+
+        assert!(ws.is_initialized());
+    }
+
+    #[test]
+    fn test_is_initialized_false() {
+        let dir = TempDir::new().unwrap();
+        let ws = make_workspace(dir.path().to_path_buf(), vec![]);
+
+        assert!(!ws.is_initialized());
+    }
+
+    #[test]
+    fn test_changelog_dir() {
+        let ws = make_workspace(PathBuf::from("/tmp/myproject"), vec![]);
+        assert_eq!(ws.changelog_dir(), PathBuf::from("/tmp/myproject/.changelog"));
+    }
+
+    #[test]
+    fn test_find_root_rust_workspace() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"foo\"]\n",
+        )
+        .unwrap();
+
+        let crate_dir = root.join("foo");
+        std::fs::create_dir_all(&crate_dir).unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\nname = \"foo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let found = Workspace::find_root(&crate_dir, Ecosystem::Rust).unwrap();
+        assert_eq!(found, root);
+    }
+
+    #[test]
+    fn test_find_root_rust_no_workspace() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"solo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let found = Workspace::find_root(dir.path(), Ecosystem::Rust).unwrap();
+        assert_eq!(found, dir.path());
+    }
+
+    #[test]
+    fn test_find_root_python() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nname = \"mypy\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let found = Workspace::find_root(dir.path(), Ecosystem::Python).unwrap();
+        assert_eq!(found, dir.path());
+    }
+
+    #[test]
+    fn test_find_root_not_found() {
+        let dir = TempDir::new().unwrap();
+        let result = Workspace::find_root(dir.path(), Ecosystem::Rust);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Increases test coverage for this lib, from identified cargo coverage checks

## Coverage gaps addressed

| Area | What's tested |
|---|---|
| **changelog_entry** | `extract_pr_number` (squash/merge/missing/multiple), `read_all` (multi-file, README skip, empty/missing dir), `write`/`delete` roundtrips |
| **changelog_writer** | `generate_entry` — single patch, mixed bump types, major-only, multiline summaries, no-match case; `update_changelog` edge cases |
| **ecosystems/rust** | `read_version`, `write_version` (including field preservation), `update_dependency_version` across deps/dev-deps/workspace-deps |
| **workspace** | `find_root` for Rust workspaces, standalone crates, Python projects, and error case; `get_package`, `package_names`, `is_initialized`, `changelog_dir` |
| **plan** | `assemble` with dependent bumps (patch/minor/none), fixed groups, linked groups (both/single releasing), ignore list |
| **config** | Load/save roundtrip, missing file defaults, malformed TOML errors, partial config default backfill |
| **graph** | `all_dependents` transitive chains + diamond deps, `dependencies`, nonexistent packages, isolated nodes |
| **lib** | `BumpType::from_str` valid/invalid/case-insensitive |

## Notable finding

`RustAdapter::read_version` panics (rather than returning `Err`) when `[package].version` is missing — documented with `#[should_panic]` test.

## Test results

All 103 tests pass (88 unit + 15 python adapter).