### PR TITLE
fix: truncate AI diff to 32KB to prevent prompt overflow

### DIFF
--- a/.changelog/9ad60315.md
+++ b/.changelog/9ad60315.md
@@ -1,0 +1,5 @@
+---
+changelogs: patch
+---
+
+Truncated AI diff to 32KB to prevent "Prompt is too long" errors with AI commands that have smaller context windows.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -233,6 +233,19 @@ fn run_ai_generation(
 
     let package_names = workspace.package_names().join(", ");
 
+    const MAX_DIFF_BYTES: usize = 32_000;
+    let diff_to_use = if diff_to_use.len() > MAX_DIFF_BYTES {
+        let truncated = &diff_to_use[..diff_to_use.floor_char_boundary(MAX_DIFF_BYTES)];
+        format!(
+            "{}\n\n[diff truncated — showing first {}KB of {}KB]",
+            truncated,
+            MAX_DIFF_BYTES / 1000,
+            diff_to_use.len() / 1000,
+        )
+    } else {
+        diff_to_use
+    };
+
     let template = instructions.unwrap_or(DEFAULT_INSTRUCTIONS);
     let prompt = template
         .replace("{packages}", &package_names)


### PR DESCRIPTION
Truncates the git diff to 32KB before sending it to the AI command. This prevents "Prompt is too long" errors for consumers using AI tools with smaller context windows.

A truncation note is appended so the LLM knows the diff was cut short.