### PR TITLE
feat: support empty frontmatter for CI/docs-only changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "changelogs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/src/changelog_entry.rs
+++ b/src/changelog_entry.rs
@@ -401,6 +401,15 @@ Fixed bug Y.
     }
 
     #[test]
+    fn test_parse_empty_frontmatter() {
+        let content = "---\n---\n\nCI-only change, no packages bumped.";
+        let changelog = parse("test-id", content).unwrap();
+        assert!(changelog.releases.is_empty());
+        assert!(changelog.commit.is_none());
+        assert_eq!(changelog.summary, "CI-only change, no packages bumped.");
+    }
+
+    #[test]
     fn test_extract_pr_number_squash_merge() {
         assert_eq!(extract_pr_number("feat: add feature (#42)"), Some(42));
     }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -171,6 +171,9 @@ Rules:
 - Replace <package-name> with actual package names from the list above
 - Include ALL packages that were modified in the frontmatter
 - Use "patch" for bug fixes, "minor" for features, "major" for breaking changes
+- If no packages were modified (e.g. CI, docs, or config-only changes), use empty frontmatter:
+  ---
+  ---
 - Keep the summary concise (1-3 sentences)
 - Use past tense (e.g. "Added", "Fixed", "Removed")
 


### PR DESCRIPTION
Closes #58

## Problem

When a PR only touches CI, docs, or config files (e.g. `.github/workflows/`), there are no packages to bump. The AI prompt currently instructs the model to always include package names, so it either produces invalid output or picks an arbitrary package.

## Changes

1. **Updated the AI prompt** to instruct the model to use empty frontmatter (`---\n---`) when no packages were modified
2. **Added a test** confirming empty frontmatter parses correctly (the parser already supports it — `serde_yaml` parses empty YAML as `Null` which skips the mapping branch)

The parser already handled this case correctly; the issue was only in the AI prompt not mentioning it as an option.