### PR TITLE
feat: add `python-version` input for Python ecosystem

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   pypi-token:
     description: 'PyPI API token for publishing (Python)'
     required: false
+  python-version:
+    description: 'Python version for building and publishing (Python ecosystem)'
+    required: false
+    default: '3.11'
   commit:
     description: 'Commit message for version bump (overrides conventional-commit)'
     required: false
@@ -53,7 +57,7 @@ runs:
       if: inputs.ecosystem == 'python' || inputs.pypi-token != ''
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ inputs.python-version }}
 
     - name: Install Python build tools (for Python ecosystem)
       if: inputs.ecosystem == 'python' || inputs.pypi-token != ''


### PR DESCRIPTION
The action currently hardcodes `python-version: '3.11'` in the `setup-python` step. This breaks packages that declare `requires-python = ">=3.12"` in their `pyproject.toml` — `python -m build` fails silently because hatchling (and other build backends) reject the Python version.

## Changes

Adds a `python-version` input (defaults to `3.11` for backward compatibility) and uses it in the setup-python step:

```yaml
- uses: wevm/changelogs@master
  with:
    ecosystem: python
    python-version: '3.12'
    pypi-token: ${{ secrets.PYPI_TOKEN }}
```

## Context

We hit this in [tempoxyz/pympp](https://github.com/tempoxyz/pympp) where the package requires `>=3.12`. The `changelogs publish` command exits with code 1 and no visible error output because `python -m build` fails under 3.11 and the error gets swallowed by the `2>&1` capture in the publish step.