### PR TITLE
fix: improve AI version bump classification prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ Added new feature X that does Y.
 Fixed bug Z in the parser.
 ```
 
+## Custom AI Instructions
+
+Override the default AI prompt by placing an `instructions.md` file in your `.changelog/` directory:
+
+`.changelog/instructions.md`:
+
+The file contents are used as the prompt template. Use `{packages}` and `{diff}` as placeholders:
+
+```markdown
+Generate a changelog entry for this diff.
+
+Available packages: {packages}
+
+---
+<package-name>: patch
+---
+
+Description.
+
+Version rules:
+- "major": any removal or rename of public API
+- "minor": new features
+- "patch": bug fixes, internal changes
+
+{diff}
+```
+
+Priority: `--instructions` flag > `.changelog/instructions.md` > built-in default.
+
 ## Supported AI Providers
 
 The `--ai` flag and GitHub Action `ai` input accept any CLI command that reads from stdin and outputs text. The diff is piped to the command, and the output becomes the changelog entry.

--- a/README.md
+++ b/README.md
@@ -129,35 +129,6 @@ Added new feature X that does Y.
 Fixed bug Z in the parser.
 ```
 
-## Custom AI Instructions
-
-Override the default AI prompt by placing an `instructions.md` file in your `.changelog/` directory:
-
-`.changelog/instructions.md`:
-
-The file contents are used as the prompt template. Use `{packages}` and `{diff}` as placeholders:
-
-```markdown
-Generate a changelog entry for this diff.
-
-Available packages: {packages}
-
----
-<package-name>: patch
----
-
-Description.
-
-Version rules:
-- "major": any removal or rename of public API
-- "minor": new features
-- "patch": bug fixes, internal changes
-
-{diff}
-```
-
-Priority: `--instructions` flag > `.changelog/instructions.md` > built-in default.
-
 ## Supported AI Providers
 
 The `--ai` flag and GitHub Action `ai` input accept any CLI command that reads from stdin and outputs text. The diff is piped to the command, and the output becomes the changelog entry.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -261,7 +261,15 @@ fn run_ai_generation(
         diff_to_use
     };
 
-    let template = instructions.unwrap_or(DEFAULT_INSTRUCTIONS);
+    let instructions_file = workspace.changelog_dir().join("instructions.md");
+    let file_instructions = if instructions.is_none() && instructions_file.exists() {
+        std::fs::read_to_string(&instructions_file).ok()
+    } else {
+        None
+    };
+    let template = instructions
+        .or(file_instructions.as_deref())
+        .unwrap_or(DEFAULT_INSTRUCTIONS);
     let prompt = template
         .replace("{packages}", &package_names)
         .replace("{diff}", &diff_to_use);

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -171,9 +171,19 @@ Brief description of changes.
 Rules:
 - Replace <package-name> with actual package names from the list above
 - Include ALL packages that were modified in the frontmatter
-- Use "patch" for bug fixes, "minor" for features, "major" for breaking changes
 - Keep the summary concise (1-3 sentences)
 - Use past tense (e.g. "Added", "Fixed", "Removed")
+
+Version bump rules (follow strictly):
+- "major": ANY removal, rename, or change to the signature/behavior of public API — this includes
+  removing or renaming public functions, methods, types, traits, structs, enums, variants, modules,
+  CLI flags/subcommands, RPC methods, config fields, or re-exports. If external code could depend on
+  it and the change would break that code, it is major. When in doubt between major and minor,
+  choose major.
+- "minor": new features, new public API surface (new functions, types, modules, optional fields),
+  deprecations (without removal), or backward-compatible behavior changes
+- "patch": bug fixes, performance improvements, internal refactors with no public API changes,
+  documentation, tests, dependency updates
 
 Git diff:
 {diff}"#;

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -261,15 +261,7 @@ fn run_ai_generation(
         diff_to_use
     };
 
-    let instructions_file = workspace.changelog_dir().join("instructions.md");
-    let file_instructions = if instructions.is_none() && instructions_file.exists() {
-        std::fs::read_to_string(&instructions_file).ok()
-    } else {
-        None
-    };
-    let template = instructions
-        .or(file_instructions.as_deref())
-        .unwrap_or(DEFAULT_INSTRUCTIONS);
+    let template = instructions.unwrap_or(DEFAULT_INSTRUCTIONS);
     let prompt = template
         .replace("{packages}", &package_names)
         .replace("{diff}", &diff_to_use);


### PR DESCRIPTION
The default AI prompt had only a single vague line for semver guidance:

`Use patch for bug fixes, minor for features, major for breaking changes`

This led to removals of public API being classified as `patch` — e.g. removing a publicly reachable function would get tagged as a patch bump, when it's actually a breaking change.

Replaces it with explicit rules that enumerate what constitutes each bump level:

- **major**: removal/rename of public functions, types, traits, modules, CLI flags, RPC methods, config fields, re-exports. "When in doubt between major and minor, choose major."
- **minor**: new features, new public API additions, deprecations without removal
- **patch**: bug fixes, perf, internal refactors, docs, tests, deps

Co-Authored-By: onbjerg <8862627+onbjerg@users.noreply.github.com>

Prompted by: onbjerg