### PR TITLE
feat: support .changelog/instructions.md for custom AI prompts

### DIFF
--- a/.changelog/rare-foxes-write.md
+++ b/.changelog/rare-foxes-write.md
@@ -1,0 +1,5 @@
+---
+changelogs: minor
+---
+
+Added support for a `.changelog/instructions.md` file to override the default AI prompt, with priority order: `--instructions` flag > `.changelog/instructions.md` > built-in default. Updated README with documentation for this feature.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ Added new feature X that does Y.
 Fixed bug Z in the parser.
 ```
 
+## Custom AI Instructions
+
+Override the default AI prompt by placing an `instructions.md` file in your `.changelog/` directory:
+
+`.changelog/instructions.md`:
+
+The file contents are used as the prompt template. Use `{packages}` and `{diff}` as placeholders:
+
+```markdown
+Generate a changelog entry for this diff.
+
+Available packages: {packages}
+
+---
+<package-name>: patch
+---
+
+Description.
+
+Version rules:
+- "major": any removal or rename of public API
+- "minor": new features
+- "patch": bug fixes, internal changes
+
+{diff}
+```
+
+Priority: `--instructions` flag > `.changelog/instructions.md` > built-in default.
+
 ## Supported AI Providers
 
 The `--ai` flag and GitHub Action `ai` input accept any CLI command that reads from stdin and outputs text. The diff is piped to the command, and the output becomes the changelog entry.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -251,7 +251,15 @@ fn run_ai_generation(
         diff_to_use
     };
 
-    let template = instructions.unwrap_or(DEFAULT_INSTRUCTIONS);
+    let instructions_file = workspace.changelog_dir().join("instructions.md");
+    let file_instructions = if instructions.is_none() && instructions_file.exists() {
+        std::fs::read_to_string(&instructions_file).ok()
+    } else {
+        None
+    };
+    let template = instructions
+        .or(file_instructions.as_deref())
+        .unwrap_or(DEFAULT_INSTRUCTIONS);
     let prompt = template
         .replace("{packages}", &package_names)
         .replace("{diff}", &diff_to_use);


### PR DESCRIPTION
Repos can now override the default AI prompt by dropping an `instructions.md` file in `.changelog/`. This lets repos define project-specific semver classification rules without passing `--instructions` on every invocation or modifying CI workflows.

Uses `{packages}` and `{diff}` as template placeholders, same as the built-in default.

Priority: `--instructions` CLI flag > `.changelog/instructions.md` > built-in default.

Co-Authored-By: onbjerg <8862627+onbjerg@users.noreply.github.com>

Prompted by: onbjerg