### PR TITLE
fix(action): preserve contributor avatars on release pages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -349,6 +349,16 @@ runs:
             "${generate_notes_args[@]}" \
             --jq '.body' 2>/dev/null || echo "")
           
+          # Extract "What's Changed" body so we can re-include it for contributor attribution.
+          # GitHub generates release page avatars from "by @username in #NNN" entries,
+          # which only appear in the "What's Changed" section.
+          whats_changed=$(echo "$github_notes" | awk '
+            /^## What'\''s Changed/ { in_section=1; next }
+            /^## New Contributors/ { in_section=0 }
+            /^\*\*Full Changelog\*\*/ { in_section=0 }
+            in_section { print }
+          ')
+
           # Remove "What's Changed" section, keep "New Contributors" and "Full Changelog"
           github_extras=$(echo "$github_notes" | awk '
             BEGIN { skip=0 }
@@ -357,12 +367,19 @@ runs:
             /^\*\*Full Changelog\*\*/ { skip=0 }
             !skip { print }
           ')
-          
+
           # For first-ever per-crate release, skip GitHub extras (no meaningful diff)
           if [[ "$tag" == *"@"* ]] && [ -z "$previous_tag" ]; then
             github_extras=""
           fi
-          
+
+          # Re-include "What's Changed" as a collapsed section so GitHub can attribute
+          # all PR authors as release contributors, not just first-time contributors.
+          if [ -n "$whats_changed" ]; then
+            collapsed="<details><summary>What's Changed</summary>"$'\n\n'"$whats_changed"$'\n'"</details>"
+            github_extras="$collapsed"$'\n\n'"$github_extras"
+          fi
+
           # Combine: changelog content + GitHub extras (New Contributors, Full Changelog)
           if [ -n "$changelog_notes" ]; then
             notes="$changelog_notes"


### PR DESCRIPTION
## Problem

GitHub generates release page contributor avatars from `by @username in #NNN` 
entries in the release body. These entries only exist in the `## What's Changed` 
section — which the action currently strips entirely. As a result, only 
first-time contributors (listed in `## New Contributors`) get avatar display, 
while repeat contributors are silently omitted.

This was observed in the `tempoxyz/wallet` v0.2.1 release: 4 PRs from 4 authors, 
but only 1 contributor avatar shown.

## Fix

Re-include `## What's Changed` as a collapsed `<details>` section in the release 
body. This keeps the formatted CHANGELOG content as the primary visual focus, 
while preserving the contributor attribution data GitHub needs to render all authors.

Fixes #81
