### PR TITLE
fix: scope release notes to same package prefix in monorepos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -296,9 +296,25 @@ runs:
             ' "$changelog_file")
           fi
           
+          # Find previous tag with the same package prefix for accurate changelog diff.
+          # In monorepos, without this GitHub defaults to the most recent repo-wide
+          # release which pulls in unrelated commits from the entire workspace.
+          previous_tag=""
+          if [[ "$tag" == *"@"* ]]; then
+            prefix="${tag%@*}@"
+            # Pick the next-lower version after current tag (not just highest non-current)
+            previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
+          else
+            previous_tag=$(git tag --list "v*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
+          fi
+          
           # Generate GitHub's notes to get "New Contributors" and "Full Changelog"
+          generate_notes_args=(-f tag_name="$tag")
+          if [ -n "$previous_tag" ]; then
+            generate_notes_args+=(-f previous_tag_name="$previous_tag")
+          fi
           github_notes=$(gh api repos/${{ github.repository }}/releases/generate-notes \
-            -f tag_name="$tag" \
+            "${generate_notes_args[@]}" \
             --jq '.body' 2>/dev/null || echo "")
           
           # Remove "What's Changed" section, keep "New Contributors" and "Full Changelog"
@@ -310,6 +326,11 @@ runs:
             !skip { print }
           ')
           
+          # For first-ever per-crate release, skip GitHub extras (no meaningful diff)
+          if [[ "$tag" == *"@"* ]] && [ -z "$previous_tag" ]; then
+            github_extras=""
+          fi
+          
           # Combine: changelog content + GitHub extras (New Contributors, Full Changelog)
           if [ -n "$changelog_notes" ]; then
             notes="$changelog_notes"
@@ -317,7 +338,9 @@ runs:
               notes="$notes"$'\n\n'"$github_extras"
             fi
             echo "$notes" | gh release create "$tag" --notes-file - || true
+          elif [ -n "$github_notes" ]; then
+            echo "$github_notes" | gh release create "$tag" --notes-file - || true
           else
-            gh release create "$tag" --generate-notes || true
+            gh release create "$tag" --notes "" || true
           fi
         done

--- a/action.yml
+++ b/action.yml
@@ -302,10 +302,19 @@ runs:
           previous_tag=""
           if [[ "$tag" == *"@"* ]]; then
             prefix="${tag%@*}@"
-            # Pick the next-lower version after current tag (not just highest non-current)
+            # Pick the next-lower version after current tag (not just highest non-current).
+            # awk finds the current tag in the desc-sorted list and prints the one after it.
+            # Falls back to grep if the current tag isn't in the list yet (shouldn't happen
+            # since "Push git tags" runs before this step, but just in case).
             previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
+            if [ -z "$previous_tag" ]; then
+              previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | grep -Fxv -- "$tag" | head -1)
+            fi
           else
             previous_tag=$(git tag --list "v*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
+            if [ -z "$previous_tag" ]; then
+              previous_tag=$(git tag --list "v*" --sort=-version:refname | grep -Fxv -- "$tag" | head -1)
+            fi
           fi
           
           # Generate GitHub's notes to get "New Contributors" and "Full Changelog"

--- a/action.yml
+++ b/action.yml
@@ -296,16 +296,11 @@ runs:
             ' "$changelog_file")
           fi
           
-          # Find previous tag with the same package prefix for accurate changelog diff.
-          # In monorepos, without this GitHub defaults to the most recent repo-wide
-          # release which pulls in unrelated commits from the entire workspace.
+          # Find previous tag with the same package prefix for accurate changelog diff
           previous_tag=""
           if [[ "$tag" == *"@"* ]]; then
             prefix="${tag%@*}@"
-            # Pick the next-lower version after current tag (not just highest non-current).
-            # awk finds the current tag in the desc-sorted list and prints the one after it.
-            # Falls back to grep if the current tag isn't in the list yet (shouldn't happen
-            # since "Push git tags" runs before this step, but just in case).
+            # Pick the next-lower version after current tag, with grep fallback
             previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
             if [ -z "$previous_tag" ]; then
               previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | grep -Fxv -- "$tag" | head -1)


### PR DESCRIPTION
When creating GitHub releases for per-crate tags (e.g. `pkg@1.5.1`), the action calls GitHub's `releases/generate-notes` API without `previous_tag_name`. GitHub defaults to the most recent repo-wide release, so the "Full Changelog" link and "New Contributors" section include **all** commits across the workspace — not just those relevant to the released crate.

**Example:** [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) showed `v1.5.0...tempo-alloy@1.5.1` which spanned ~80 unrelated node commits (already fixed though).

## Changes

- Find the previous tag matching the same package prefix (e.g. `tempo-alloy@1.5.0`) and pass it as `previous_tag_name`
- Use next-lower version ordering (not highest non-current) so parallel release lines / backports pick the correct predecessor
- Skip GitHub-generated extras for first-ever per-crate releases (no prior tag = no meaningful diff)
- Remove fallback to `gh release create --generate-notes` which bypassed the explicit `previous_tag_name`

Prompted by: rusowsky