### PR TITLE
fix: use no_deps in cargo metadata for package discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "changelogs"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/src/ecosystems/mod.rs
+++ b/src/ecosystems/mod.rs
@@ -91,7 +91,7 @@ pub trait EcosystemAdapter {
         Self: Sized;
 
     /// Discovers packages in the given root directory.
-    fn discover(root: &Path) -> Result<Vec<Package>>
+    fn discover(root: &Path, skip_dep_resolution: bool) -> Result<Vec<Package>>
     where
         Self: Sized;
 
@@ -151,10 +151,14 @@ pub fn detect_ecosystem(start: &Path) -> Option<Ecosystem> {
     }
 }
 
-pub fn discover_packages(ecosystem: Ecosystem, root: &Path) -> Result<Vec<Package>> {
+pub fn discover_packages(
+    ecosystem: Ecosystem,
+    root: &Path,
+    skip_dep_resolution: bool,
+) -> Result<Vec<Package>> {
     match ecosystem {
-        Ecosystem::Rust => RustAdapter::discover(root),
-        Ecosystem::Python => PythonAdapter::discover(root),
+        Ecosystem::Rust => RustAdapter::discover(root, skip_dep_resolution),
+        Ecosystem::Python => PythonAdapter::discover(root, skip_dep_resolution),
     }
 }
 

--- a/src/ecosystems/python.rs
+++ b/src/ecosystems/python.rs
@@ -14,7 +14,7 @@ impl EcosystemAdapter for PythonAdapter {
         Ecosystem::Python
     }
 
-    fn discover(root: &Path) -> Result<Vec<Package>> {
+    fn discover(root: &Path, _skip_dep_resolution: bool) -> Result<Vec<Package>> {
         let pyproject_path = root.join("pyproject.toml");
 
         if !pyproject_path.exists() {
@@ -565,7 +565,7 @@ dependencies = ["requests>=2.0"]
 "#,
         );
 
-        let packages = PythonAdapter::discover(tmp.path()).unwrap();
+        let packages = PythonAdapter::discover(tmp.path(), false).unwrap();
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].name, "my-package");
         assert_eq!(packages[0].version.to_string(), "1.2.3");
@@ -575,7 +575,7 @@ dependencies = ["requests>=2.0"]
     #[test]
     fn discover_missing_pyproject() {
         let tmp = TempDir::new().unwrap();
-        let result = PythonAdapter::discover(tmp.path());
+        let result = PythonAdapter::discover(tmp.path(), false);
         assert!(result.is_err());
         assert!(
             result
@@ -597,7 +597,7 @@ build-backend = "hatchling.build"
 "#,
         );
 
-        let result = PythonAdapter::discover(tmp.path());
+        let result = PythonAdapter::discover(tmp.path(), false);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("[project]") || err.contains("[tool.poetry]"));
@@ -615,7 +615,7 @@ dynamic = ["version"]
 "#,
         );
 
-        let result = PythonAdapter::discover(tmp.path());
+        let result = PythonAdapter::discover(tmp.path(), false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Dynamic"));
     }
@@ -631,7 +631,7 @@ name = "my-package"
 "#,
         );
 
-        let result = PythonAdapter::discover(tmp.path());
+        let result = PythonAdapter::discover(tmp.path(), false);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         // Falls through to error about missing [project] or [tool.poetry] with valid version
@@ -816,7 +816,7 @@ click = "^8.0"
 "#,
         );
 
-        let packages = PythonAdapter::discover(tmp.path()).unwrap();
+        let packages = PythonAdapter::discover(tmp.path(), false).unwrap();
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].name, "poetry-pkg");
         assert_eq!(packages[0].version.to_string(), "0.5.0");
@@ -845,7 +845,7 @@ black = "^23.0"
 "#,
         );
 
-        let packages = PythonAdapter::discover(tmp.path()).unwrap();
+        let packages = PythonAdapter::discover(tmp.path(), false).unwrap();
         assert_eq!(packages.len(), 1);
         assert!(packages[0].dependencies.contains(&"requests".to_string()));
         assert!(packages[0].dependencies.contains(&"pytest".to_string()));
@@ -894,7 +894,7 @@ version = "2.0.0"
 "#,
         );
 
-        let packages = PythonAdapter::discover(tmp.path()).unwrap();
+        let packages = PythonAdapter::discover(tmp.path(), false).unwrap();
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].name, "pep621-pkg");
         assert_eq!(packages[0].version.to_string(), "1.0.0");
@@ -911,7 +911,7 @@ name = "test-pkg"
 version = "1.0.0"
 "#,
         );
-        let pkg = &PythonAdapter::discover(tmp.path()).unwrap()[0];
+        let pkg = &PythonAdapter::discover(tmp.path(), false).unwrap()[0];
         let result = PythonAdapter::publish(pkg, true, None).unwrap();
         assert_eq!(result, PublishResult::Success);
     }
@@ -927,7 +927,7 @@ name = "test-pkg"
 version = "1.0.0"
 "#,
         );
-        let pkg = &PythonAdapter::discover(tmp.path()).unwrap()[0];
+        let pkg = &PythonAdapter::discover(tmp.path(), false).unwrap()[0];
         // Ensure tokens are not set
         // SAFETY: test-only, no concurrent access to these env vars
         unsafe {

--- a/src/ecosystems/rust.rs
+++ b/src/ecosystems/rust.rs
@@ -15,7 +15,7 @@ impl EcosystemAdapter for RustAdapter {
     }
 
     fn discover(root: &Path) -> Result<Vec<Package>> {
-        let metadata = MetadataCommand::new().current_dir(root).exec()?;
+        let metadata = MetadataCommand::new().no_deps().current_dir(root).exec()?;
 
         let workspace_members: std::collections::HashSet<_> =
             metadata.workspace_members.iter().collect();

--- a/src/ecosystems/rust.rs
+++ b/src/ecosystems/rust.rs
@@ -15,6 +15,8 @@ impl EcosystemAdapter for RustAdapter {
     }
 
     fn discover(root: &Path) -> Result<Vec<Package>> {
+        // Skip dependency resolution — we only need workspace member info (names, versions, paths).
+        // Full resolution tries to fetch git sources which fails in CI without a cargo cache.
         let metadata = MetadataCommand::new().no_deps().current_dir(root).exec()?;
 
         let workspace_members: std::collections::HashSet<_> =

--- a/src/ecosystems/rust.rs
+++ b/src/ecosystems/rust.rs
@@ -14,10 +14,16 @@ impl EcosystemAdapter for RustAdapter {
         Ecosystem::Rust
     }
 
-    fn discover(root: &Path) -> Result<Vec<Package>> {
-        // Skip dependency resolution — we only need workspace member info (names, versions, paths).
-        // Full resolution tries to fetch git sources which fails in CI without a cargo cache.
-        let metadata = MetadataCommand::new().no_deps().current_dir(root).exec()?;
+    fn discover(root: &Path, skip_dep_resolution: bool) -> Result<Vec<Package>> {
+        let mut cmd = MetadataCommand::new();
+        cmd.current_dir(root);
+        // When the ecosystem is explicitly known, skip dependency resolution since we only need
+        // workspace member info (names, versions, paths). Full resolution fetches git sources
+        // which fails in CI without a cargo cache.
+        if skip_dep_resolution {
+            cmd.no_deps();
+        }
+        let metadata = cmd.exec()?;
 
         let workspace_members: std::collections::HashSet<_> =
             metadata.workspace_members.iter().collect();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -22,12 +22,13 @@ impl Workspace {
     pub fn discover_with_ecosystem(ecosystem: Option<Ecosystem>) -> Result<Self> {
         let cwd = std::env::current_dir()?;
 
+        let explicit = ecosystem.is_some();
         let ecosystem = ecosystem
             .or_else(|| ecosystems::detect_ecosystem(&cwd))
             .ok_or(Error::NotInWorkspace)?;
 
         let root = Self::find_root(&cwd, ecosystem)?;
-        let packages = ecosystems::discover_packages(ecosystem, &root)?;
+        let packages = ecosystems::discover_packages(ecosystem, &root, explicit)?;
 
         if packages.is_empty() {
             return Err(Error::NotInWorkspace);

--- a/tests/python_adapter.rs
+++ b/tests/python_adapter.rs
@@ -17,7 +17,7 @@ fn create_pyproject(dir: &std::path::Path, content: &str) {
 #[test]
 fn test_python_discover() {
     let root = fixture_path("python-simple");
-    let packages = PythonAdapter::discover(&root).unwrap();
+    let packages = PythonAdapter::discover(&root, false).unwrap();
 
     assert_eq!(packages.len(), 1);
     assert_eq!(packages[0].name, "my-package");
@@ -74,7 +74,7 @@ build-backend = "hatchling.build"
 "#;
     std::fs::write(&pyproject_path, content).unwrap();
 
-    let result = PythonAdapter::discover(temp_dir.path());
+    let result = PythonAdapter::discover(temp_dir.path(), false);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.to_string().contains("Dynamic versions"));
@@ -91,7 +91,7 @@ build-backend = "hatchling.build"
 "#;
     std::fs::write(&pyproject_path, content).unwrap();
 
-    let result = PythonAdapter::discover(temp_dir.path());
+    let result = PythonAdapter::discover(temp_dir.path(), false);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.to_string().contains("[project]"));
@@ -230,7 +230,7 @@ dependencies = [
 "#,
     );
 
-    let packages = PythonAdapter::discover(temp_dir.path()).unwrap();
+    let packages = PythonAdapter::discover(temp_dir.path(), false).unwrap();
     let deps = &packages[0].dependencies;
 
     assert!(deps.contains(&"foo-bar".to_string()));
@@ -285,7 +285,7 @@ pytest = "^7.0"
 "#,
     );
 
-    let packages = PythonAdapter::discover(temp_dir.path()).unwrap();
+    let packages = PythonAdapter::discover(temp_dir.path(), false).unwrap();
 
     assert_eq!(packages.len(), 1);
     assert_eq!(packages[0].name, "poetry-package");
@@ -342,7 +342,7 @@ version = "2.0.0"
 "#,
     );
 
-    let packages = PythonAdapter::discover(temp_dir.path()).unwrap();
+    let packages = PythonAdapter::discover(temp_dir.path(), false).unwrap();
 
     assert_eq!(packages.len(), 1);
     assert_eq!(packages[0].name, "pep621-package");


### PR DESCRIPTION
When `--ecosystem` is passed explicitly (e.g. `changelogs --ecosystem rust add` in CI), skip `cargo metadata` dependency resolution via `--no-deps` since we only need workspace member info (names, versions, paths). When the ecosystem is auto-detected (no flag), keep full resolution for local usage where cargo can resolve git deps.

Without this, `cargo metadata` tries to fetch all git sources (e.g. reth) which fails in lightweight CI environments that don't have a cargo cache.

Failing CI run: https://github.com/tempoxyz/tempo/actions/runs/24393564180/job/71245552144

Prompted by: rusowsky