### PR TITLE
fix: handle per-crate changelog headings and directory lookups

### DIFF
--- a/.changelog/tidy-clouds-clean.md
+++ b/.changelog/tidy-clouds-clean.md
@@ -1,0 +1,5 @@
+---
+changelogs: patch
+---
+
+Fixed changelog directory lookup to support hyphenated package names by stripping the first prefix segment as a fallback (e.g., `tempo-alloy` -> `alloy`). Also improved release notes extraction to match both backtick-wrapped tag headings and plain version headings.

--- a/action.yml
+++ b/action.yml
@@ -278,6 +278,18 @@ runs:
                 break
               fi
             done
+            # Fallback: try stripping first prefix (e.g., "tempo-alloy" -> "alloy")
+            if [ -z "$changelog_file" ]; then
+              stripped="${pkg_name#*-}"
+              if [ "$stripped" != "$pkg_name" ]; then
+                for dir in "crates/$stripped" "packages/$stripped" "$stripped"; do
+                  if [ -f "$dir/CHANGELOG.md" ]; then
+                    changelog_file="$dir/CHANGELOG.md"
+                    break
+                  fi
+                done
+              fi
+            fi
           fi
           # Fall back to root CHANGELOG.md
           if [ -z "$changelog_file" ] && [ -f "CHANGELOG.md" ]; then
@@ -294,11 +306,19 @@ runs:
               version="$tag"
             fi
             
-            changelog_notes=$(awk -v ver="$version" '
-              BEGIN { printing=0 }
+            changelog_notes=$(awk -v ver="$version" -v tag="$tag" '
+              BEGIN {
+                printing=0
+                root_prefix="## " ver
+                tag_prefix="## `" tag "`"
+              }
               /^## / {
                 if (printing) exit
-                if ($0 ~ "^## " ver "[ (]") { printing=1; next }
+                if (index($0, tag_prefix) == 1) { printing=1; next }
+                if (index($0, root_prefix) == 1) {
+                  c = substr($0, length(root_prefix) + 1, 1)
+                  if (c == " " || c == "(" || c == "") { printing=1; next }
+                }
               }
               printing { print }
             ' "$changelog_file")


### PR DESCRIPTION
## Summary
Fix release creation for repos where crate directory names don't match the tag prefix.

## Motivation
`tempoxyz/tempo` release workflow failed at [this job](https://github.com/tempoxyz/tempo/actions/runs/24401821088/job/712741916811) because:
1. Tag `tempo-alloy@1.6.0` → looked for `crates/tempo-alloy/CHANGELOG.md`, but actual dir is `crates/alloy/`
2. Per-crate headings are ```## `tempo-alloy@1.6.0```` but awk only matched `## 1.6.0[ (]`

## Changes
- Add stripped-prefix fallback for crate directory lookup (`tempo-alloy` → tries exact first, then falls back to `alloy`)
- Match both `## version (date)` (root format) and ```## `tag```` (per-crate format) heading styles
- Use `index()` string-prefix matching instead of regex interpolation for robustness

## Testing
Verified against all consumer repos (`tempo`, `wallet`, `mpp-rs`, `pytempo`) — 16/16 test cases pass with no regressions:
- `tempo-alloy@1.6.0` (per-crate, stripped dir fallback + backtick heading) ✓
- `v0.4.1` on wallet (root, v-prefixed) ✓
- `v0.9.2` on mpp-rs (root, v-prefixed) ✓
- `pytempo@0.5.0` (root, pkg@ tag) ✓
- Edge cases: nonexistent versions, unknown pkgs, version prefix collisions ✓

Prompted by: rusowsky