### PR TITLE
chore: release `v0.6.4`

### DIFF
--- a/.changelog/tidy-clouds-clean.md
+++ b/.changelog/tidy-clouds-clean.md
@@ -1,5 +1,0 @@
----
-changelogs: patch
----
-
-Fixed changelog directory lookup to support hyphenated package names by stripping the first prefix segment as a fallback (e.g., `tempo-alloy` -> `alloy`). Also improved release notes extraction to match both backtick-wrapped tag headings and plain version headings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.4 (2026-04-14)
+
+### Patch Changes
+
+- Fixed changelog directory lookup to support hyphenated package names by stripping the first prefix segment as a fallback (e.g., `tempo-alloy` -> `alloy`). Also improved release notes extraction to match both backtick-wrapped tag headings and plain version headings. (by @DerekCofausper, [#87](https://github.com/tempoxyz/changelogs/pull/87))
+
 ## 0.6.3 (2026-03-18)
 
 ### Patch Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "changelogs"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/wevm/changelogs-rs"


### PR DESCRIPTION
This PR was opened by the Changelogs release workflow.

When you're ready to release, merge this PR and the packages will be published.

---

## 0.6.4 (2026-04-14)

### Patch Changes

- Fixed changelog directory lookup to support hyphenated package names by stripping the first prefix segment as a fallback (e.g., `tempo-alloy` -> `alloy`). Also improved release notes extraction to match both backtick-wrapped tag headings and plain version headings. (by @DerekCofausper, [#87](https://github.com/tempoxyz/changelogs/pull/87))

