### PR TITLE
chore: release `v0.6.5`

### DIFF
--- a/.changelog/fix-rustls-webpki.md
+++ b/.changelog/fix-rustls-webpki.md
@@ -1,5 +1,0 @@
----
-changelogs: patch
----
-
-Update rustls-webpki 0.103.11 → 0.103.13 to fix RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.5 (2026-04-25)
+
+### Patch Changes
+
+- Update rustls-webpki 0.103.11 → 0.103.13 to fix RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104. (by @grandizzy, [#107](https://github.com/tempoxyz/changelogs/pull/107))
+
 ## 0.6.4 (2026-04-14)
 
 ### Patch Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "changelogs"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/wevm/changelogs-rs"


### PR DESCRIPTION
This PR was opened by the Changelogs release workflow.

When you're ready to release, merge this PR and the packages will be published.

---

## 0.6.5 (2026-04-25)

### Patch Changes

- Update rustls-webpki 0.103.11 → 0.103.13 to fix RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104. (by @grandizzy, [#107](https://github.com/tempoxyz/changelogs/pull/107))

