### PR TITLE
fix: skip Go bootstrap publish + harden release-notes grep

### DIFF
--- a/.changelog/quiet-frogs-leap.md
+++ b/.changelog/quiet-frogs-leap.md
@@ -1,0 +1,8 @@
+---
+changelogs: patch
+---
+
+Two release-mode fixes:
+
+- **Go ecosystem.** `is_published` now treats `v0.0.0` as already published, so a Go module with no prior `vX.Y.Z` tag and no staged changelog entries does not get bootstrap-tagged on every push to the release branch. The previous behavior unconditionally created and pushed a `v0.0.0` tag the first time the release workflow ran on an integrated repo.
+- **GitHub Action.** The "Create GitHub releases" step's previous-tag lookup uses `git tag --list … | grep -Fxv -- "$tag" | head -1`. `grep -Fxv` exits 1 when every input line matches the excluded pattern (i.e. when the only tag is `$tag` itself), and under `set -e -o pipefail` that aborted the whole step before any release was created. Both occurrences are now guarded with `{ grep -Fxv … || true; }`, so the lookup degrades to "no previous tag" instead of failing the step.

--- a/action.yml
+++ b/action.yml
@@ -324,19 +324,24 @@ runs:
             ' "$changelog_file")
           fi
           
-          # Find previous tag with the same package prefix for accurate changelog diff
+          # Find previous tag with the same package prefix for accurate changelog diff.
+          # NOTE: `grep -Fxv` exits 1 when every input line matches the excluded
+          # pattern (i.e. when the only tag is `$tag` itself), and under
+          # `set -e -o pipefail` that aborts the whole "Create GitHub releases"
+          # step before any release is created. The `|| true` after each grep
+          # pipeline degrades that case to "no previous tag" instead of failing.
           previous_tag=""
           if [[ "$tag" == *"@"* ]]; then
             prefix="${tag%@*}@"
             # Pick the next-lower version after current tag, with grep fallback
             previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
             if [ -z "$previous_tag" ]; then
-              previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | grep -Fxv -- "$tag" | head -1)
+              previous_tag=$(git tag --list "${prefix}*" --sort=-version:refname | { grep -Fxv -- "$tag" || true; } | head -1)
             fi
           else
             previous_tag=$(git tag --list "v*" --sort=-version:refname | awk -v cur="$tag" '$0==cur{found=1;next} found{print;exit}')
             if [ -z "$previous_tag" ]; then
-              previous_tag=$(git tag --list "v*" --sort=-version:refname | grep -Fxv -- "$tag" | head -1)
+              previous_tag=$(git tag --list "v*" --sort=-version:refname | { grep -Fxv -- "$tag" || true; } | head -1)
             fi
           fi
           

--- a/src/ecosystems/go.rs
+++ b/src/ecosystems/go.rs
@@ -106,6 +106,17 @@ impl EcosystemAdapter for GoAdapter {
     fn is_published(name: &str, version: &Version) -> Result<bool> {
         // `name` is the full module path (set in `discover`). Query the Go module
         // proxy directly so already-released versions are skipped on republish.
+        //
+        // Special case: `v0.0.0` is the implicit baseline returned by `discover`
+        // when there is no `// changelogs:version` comment in `go.mod` and no
+        // existing `vX.Y.Z` git tag — i.e. this module has never had a real
+        // release. Treat it as "already published" so the publisher does NOT
+        // bootstrap-tag `v0.0.0` on every push to the release branch. A real
+        // first release happens once a changelog entry bumps the version
+        // (e.g. to `v0.1.0`) and `is_published` queries the proxy for that.
+        if *version == Version::new(0, 0, 0) {
+            return Ok(true);
+        }
         check_proxy_published(name, version)
     }
 
@@ -586,6 +597,16 @@ mod tests {
             GoAdapter::publish(pkg, true, None).unwrap(),
             PublishResult::Success
         );
+    }
+
+    #[test]
+    fn is_published_skips_bootstrap_v0_0_0() {
+        // v0.0.0 is the implicit baseline `discover` returns when there is no
+        // version comment and no git tag. `is_published` must report it as
+        // already published so the publisher does not bootstrap-tag the repo
+        // on every push to the release branch. This case is short-circuited
+        // before any network call, so it's safe to run offline.
+        assert!(GoAdapter::is_published("github.com/foo/bar", &Version::new(0, 0, 0)).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two release-mode regressions surfaced when the action ran on a Go repo (`tempoxyz/mpp-go`) for the first time, with no prior `vX.Y.Z` tag and no staged changelog entries. Both are fixed here in a single PR. Each fix is isolated to one diff hunk; reviewers can land them independently if preferred.

### Repro

The release workflow on [`mpp-go`](https://github.com/tempoxyz/mpp-go) ran on the merge of an integration PR that wired up `tempoxyz/changelogs` but intentionally added no staged entries. The job [`74052740537`](https://github.com/tempoxyz/mpp-go/actions/runs/25254961920/job/74052740537) emitted:

```
🚀 Publishing 1 package(s)...
  github.com/tempoxyz/mpp-go v0.0.0 ... ✓
Created git tag: v0.0.0
…
git push --follow-tags  →  * [new tag] v0.0.0 -> v0.0.0
…
Creating release for v0.0.0
##[error]Process completed with exit code 1.
```

Two distinct bugs were chained together: the publisher should not have tagged anything at all (Bug #1), and the release-notes step shouldn't have failed silently (Bug #2).

---

## Bug #1 — Go ecosystem bootstraps `v0.0.0` on empty publish

**Code path:** [`src/ecosystems/go.rs`](https://github.com/tempoxyz/changelogs/blob/master/src/ecosystems/go.rs)

`GoAdapter::discover` returns a `Package` at `Version::new(0, 0, 0)` when there is no `// changelogs:version` comment in `go.mod` and no existing `vX.Y.Z` git tag — the implicit baseline for an unreleased module:

```rust
let version = read_version_from_content(&content)
    .or_else(|| latest_git_tag_version(root))
    .unwrap_or_else(|| Version::new(0, 0, 0));
```

`GoAdapter::is_published` then queried `proxy.golang.org/.../@v/v0.0.0.info`, got 404, and reported `Ok(false)`. The publisher took that as "needs publishing", returned `PublishResult::Success` (Go publish is a no-op — tagging is the orchestrator's job), and `cli/publish.rs::create_git_tags` created and pushed a `v0.0.0` tag.

This means **every** Go repo that adopts `changelogs` gets a spurious `v0.0.0` tag the first time the release workflow runs after merge — before any real changelog entry exists. `proxy.golang.org` happily indexes `v0.0.0`, which makes it harder to ever do a clean `v0.1.0` first release.

**Fix:** Treat `v0.0.0` as "already published" in `GoAdapter::is_published`. The first real release happens once a changelog entry bumps the version to something concrete (e.g. `v0.1.0`), which `is_published` queries normally.

```rust
if *version == Version::new(0, 0, 0) {
    return Ok(true);
}
check_proxy_published(name, version)
```

A unit test (`is_published_skips_bootstrap_v0_0_0`) covers the new short-circuit. It runs offline because the early return happens before the proxy call.

### Why short-circuit in `is_published` rather than filter in `discover`?

`discover()` is also used by the `version`, `status`, and `add` commands, which need to see the package even before its first release so they can stage the bump from `0.0.0 → 0.1.0`. The publish path is the only one where the implicit baseline becomes spurious, so the fix lives there.

---

## Bug #2 — `Create GitHub releases` step exits 1 silently

**Code path:** [`action.yml`](https://github.com/tempoxyz/changelogs/blob/master/action.yml) — `Create GitHub releases` step.

The previous-tag lookup runs:

```bash
previous_tag=$(git tag --list "v*" --sort=-version:refname \
  | grep -Fxv -- "$tag" \
  | head -1)
```

`grep -Fxv` exits **1** when every input line matches the excluded pattern (i.e. when the only tag is `$tag` itself, which is exactly the case on the first release). The shell runs with `bash --noprofile --norc -e -o pipefail`, so a non-zero exit anywhere in the pipeline aborts the entire step — *even though every `gh release create` invocation later in the script is already wrapped in `|| true`*.

That's why the workflow log shows `Creating release for v0.0.0` then `Process completed with exit code 1` with nothing else: the failure happens earlier in the loop body, before any release is attempted.