### PR TITLE
chore(ci): group dependabot PRs and open release PR as github-actions[bot]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,18 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      default-days: 3
+      semver-major-days: 7
     groups:
-      cargo-weekly:
-        applies-to: "version-updates"
+      cargo:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      default-days: 3
     groups:
-      actions-weekly:
-        applies-to: "version-updates"
+      actions:
         patterns: ["*"]
-        update-types: ["minor", "patch"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,15 @@ jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Install Rust
@@ -32,6 +36,5 @@ jobs:
         with:
           crate-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           conventional-commit: true
-          github-token: ${{ secrets.GH_PAT }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two CI hygiene changes, both modeled on what `tempoxyz/tempo-go` does today.

## 1. Group all Dependabot updates per ecosystem

The current `.github/dependabot.yml` restricts grouping to `applies-to: version-updates` with `update-types: ["minor", "patch"]`. As a result, every major bump opens a separate PR (see #94, #103, #104, #105, #106, #93, #91, #95, #99, …), which is what we're seeing right now in the PR list.

This PR drops the `applies-to` / `update-types` filters so all updates — including majors — are batched into a single PR per ecosystem (`cargo`, `actions`). That matches [`tempoxyz/tempo-go`'s dependabot config](https://github.com/tempoxyz/tempo-go/blob/main/.github/dependabot.yml) which produces PRs like _"chore(deps): bump the actions group across 1 directory with 4 updates"_.

Cooldown is also aligned with tempo-go (`default-days: 3`, `semver-major-days: 7` for cargo).

## 2. Release PR authored by `github-actions[bot]`

Today `.github/workflows/release.yml` checks out and runs the changelogs action with `secrets.GH_PAT`, so the release PR (e.g. #110) shows up authored by @Slokh. That's confusing — it looks like a human PR.

Switching to the default `secrets.GITHUB_TOKEN` (with explicit `contents: write` + `pull-requests: write` job permissions) makes the release PR authored by `github-actions[bot]`, which is the same setup [`tempo-go`'s changelog-release workflow](https://github.com/tempoxyz/tempo-go/blob/main/.github/workflows/changelog-release.yml) uses.

Also added `fetch-depth: 0` and `fetch-tags: true` on checkout so the action can read prior tags when computing the next version (also matching tempo-go).

Note: `secrets.CARGO_REGISTRY_TOKEN` is preserved for the publish step.

## Test plan

- After merge, the next Dependabot run should produce at most two open PRs (one for `cargo`, one for `actions`).
- The next release PR should be authored by `github-actions[bot]`.