### PR TITLE
fix: gate pypi auth to python ecosystem

### DIFF
--- a/.changelog/gate-pypi-auth.md
+++ b/.changelog/gate-pypi-auth.md
@@ -1,0 +1,5 @@
+---
+changelogs: patch
+---
+
+Gate PyPI authentication setup to the explicit Python ecosystem so non-Python release workflows that use OIDC for their own registry do not attempt PyPI trusted publishing.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ Changelogs supports Python packages using PEP 621 `pyproject.toml` files.
 You can authenticate to PyPI with either a static API token or [Trusted
 Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC). The action picks
 OIDC automatically when `pypi-token` is empty and the workflow has
-`id-token: write`.
+`id-token: write`. PyPI auth setup only runs when `ecosystem: python` is set, so
+include that input for both static-token and Trusted Publishing workflows.
 
 Static API token:
 

--- a/action.yml
+++ b/action.yml
@@ -56,17 +56,17 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    # Also run when OIDC is available so auto-detected Python repos using
-    # Trusted Publishing (no `ecosystem: python`, no `pypi-token`) still get
-    # build/twine installed.
+    # Python tooling is only needed when the caller explicitly selects the
+    # Python ecosystem. Other ecosystems can use GitHub OIDC for their own
+    # registries, so OIDC availability alone must not trigger PyPI setup.
     - name: Setup Python (for Python ecosystem)
-      if: inputs.ecosystem == 'python' || inputs.pypi-token != '' || env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != ''
+      if: inputs.ecosystem == 'python'
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install Python build tools (for Python ecosystem)
-      if: inputs.ecosystem == 'python' || inputs.pypi-token != '' || env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != ''
+      if: inputs.ecosystem == 'python'
       shell: bash
       run: pip install build==1.2.2.post1 twine==6.2.0
 
@@ -221,12 +221,11 @@ runs:
     #      API token by exchanging the GitHub OIDC ID token at PyPI's
     #      `_/oidc/mint-token` endpoint. Requires a configured Trusted
     #      Publisher on the PyPI project that matches the workflow.
-    # Run unconditionally on the publish path so it works with the documented
-    # ecosystem auto-detection (no `ecosystem: python` set) when using OIDC
-    # trusted publishing. Setting TWINE_PASSWORD is a no-op for non-Python
-    # publishes.
+    # Run only for explicit Python publish workflows. Non-Python workflows can
+    # also have GitHub OIDC enabled for their own registries, and must not try
+    # to exchange that OIDC token with PyPI.
     - name: Configure PyPI auth
-      if: steps.check.outputs.hasChangelogs == 'false'
+      if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python'
       shell: bash
       env:
         PYPI_TOKEN_INPUT: ${{ inputs.pypi-token }}


### PR DESCRIPTION
## Summary
- Run Python setup/build-tool installation only when the action is explicitly invoked with `ecosystem: python`.
- Run PyPI authentication only for Python publish workflows, so Rust releases using OIDC for crates.io do not attempt PyPI trusted publishing.
- Update the Python auth docs and add a patch changelog entry.