### PR TITLE
Add SwiftPM ecosystem support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "changelogs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -360,6 +360,41 @@ github.com/owner/repo: minor
 - Single-module repos only (no Go monorepo / multi-`go.mod` support)
 - Major version bumps (≥ v2) do not currently rewrite the `module .../vN` suffix
 
+### SwiftPM
+
+Changelogs supports Swift Package Manager packages using root `Package.swift`
+files. SwiftPM versions live in **git tags**, not in the manifest. To remember
+the bumped version between the `version` and `publish` CI runs, changelogs writes
+it inline as a comment in `Package.swift`:
+
+```swift
+// swift-tools-version: 5.10
+// changelogs:version 1.2.3
+import PackageDescription
+```
+
+**Requirements:**
+- `Package.swift` at the repository root with `Package(name: "...")`
+- Semantic versioning for git tags (`v1.2.3`)
+
+**Package name:** Swift uses the package's `Package(name:)` value as the package
+name. This is what you write in changelog frontmatter:
+
+```markdown
+---
+TempoKit: minor
+---
+```
+
+**Publishing:**
+- No registry token required — pushing the git tag publishes the SwiftPM package
+- Tag format is `vX.Y.Z` (no package-name prefix)
+
+**Limitations:**
+- Single-package repos only (no Swift package monorepo support)
+- Dependency version updates currently support `.package(url: ..., from: "...")`
+  and `.package(url: ..., exact: "...")`
+
 ## License
 
 MIT OR Apache-2.0

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -16,7 +16,7 @@ pub fn run(
     ecosystem: Option<Ecosystem>,
 ) -> Result<()> {
     let workspace = Workspace::discover_with_ecosystem(ecosystem).context(
-        "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go>",
+        "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go|swift>",
     )?;
 
     if !workspace.is_initialized() {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -7,7 +7,7 @@ use console::style;
 
 pub fn run(ecosystem: Option<Ecosystem>) -> Result<()> {
     let workspace = Workspace::discover_with_ecosystem(ecosystem)
-        .context("could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go> init")?;
+        .context("could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go|swift> init")?;
 
     if workspace.is_initialized() {
         return Err(Error::AlreadyInitialized.into());

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -9,7 +9,7 @@ use console::style;
 
 pub fn run(verbose: bool, ecosystem: Option<Ecosystem>) -> Result<()> {
     let workspace = Workspace::discover_with_ecosystem(ecosystem).context(
-        "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go>",
+        "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go|swift>",
     )?;
 
     if !workspace.is_initialized() {

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 pub fn run(dry_run: bool, ecosystem: Option<Ecosystem>) -> Result<()> {
     let workspace = Workspace::discover_with_ecosystem(ecosystem).context(
-        "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go>",
+        "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go|swift>",
     )?;
 
     if !workspace.is_initialized() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,7 +119,7 @@ impl Config {
     }
 
     pub fn default_toml() -> &'static str {
-        r#"# Ecosystem: "rust" | "python" | "go" (auto-detected if not specified)
+        r#"# Ecosystem: "rust" | "python" | "go" | "swift" (auto-detected if not specified)
 # ecosystem = "rust"
 
 # How to bump packages that depend on changed packages

--- a/src/ecosystems/mod.rs
+++ b/src/ecosystems/mod.rs
@@ -1,10 +1,12 @@
 mod go;
 mod python;
 mod rust;
+mod swift;
 
 pub use go::GoAdapter;
 pub use python::PythonAdapter;
 pub use rust::RustAdapter;
+pub use swift::SwiftAdapter;
 
 use crate::error::Result;
 use semver::Version;
@@ -19,12 +21,14 @@ pub enum Ecosystem {
     Rust,
     Python,
     Go,
+    Swift,
 }
 
 impl Ecosystem {
     const RUST_ALIASES: &[&str] = &["rust", "cargo"];
     const PYTHON_ALIASES: &[&str] = &["python", "pypi"];
     const GO_ALIASES: &[&str] = &["go", "golang"];
+    const SWIFT_ALIASES: &[&str] = &["swift", "swiftpm", "spm"];
 
     pub fn from_alias(s: &str) -> Option<Self> {
         let lower = s.to_lowercase();
@@ -34,6 +38,8 @@ impl Ecosystem {
             Some(Ecosystem::Python)
         } else if Self::GO_ALIASES.contains(&lower.as_str()) {
             Some(Ecosystem::Go)
+        } else if Self::SWIFT_ALIASES.contains(&lower.as_str()) {
+            Some(Ecosystem::Swift)
         } else {
             None
         }
@@ -66,6 +72,7 @@ impl std::fmt::Display for Ecosystem {
             Ecosystem::Rust => write!(f, "rust"),
             Ecosystem::Python => write!(f, "python"),
             Ecosystem::Go => write!(f, "go"),
+            Ecosystem::Swift => write!(f, "swift"),
         }
     }
 }
@@ -153,6 +160,9 @@ pub fn detect_ecosystem(start: &Path) -> Option<Ecosystem> {
         if current.join("go.mod").exists() {
             return Some(Ecosystem::Go);
         }
+        if current.join("Package.swift").exists() {
+            return Some(Ecosystem::Swift);
+        }
 
         match current.parent() {
             Some(parent) => current = parent.to_path_buf(),
@@ -166,6 +176,7 @@ pub fn discover_packages(ecosystem: Ecosystem, root: &Path) -> Result<Vec<Packag
         Ecosystem::Rust => RustAdapter::discover(root),
         Ecosystem::Python => PythonAdapter::discover(root),
         Ecosystem::Go => GoAdapter::discover(root),
+        Ecosystem::Swift => SwiftAdapter::discover(root),
     }
 }
 
@@ -174,6 +185,7 @@ pub fn read_version(ecosystem: Ecosystem, manifest_path: &Path) -> Result<Versio
         Ecosystem::Rust => RustAdapter::read_version(manifest_path),
         Ecosystem::Python => PythonAdapter::read_version(manifest_path),
         Ecosystem::Go => GoAdapter::read_version(manifest_path),
+        Ecosystem::Swift => SwiftAdapter::read_version(manifest_path),
     }
 }
 
@@ -182,6 +194,7 @@ pub fn write_version(ecosystem: Ecosystem, manifest_path: &Path, version: &Versi
         Ecosystem::Rust => RustAdapter::write_version(manifest_path, version),
         Ecosystem::Python => PythonAdapter::write_version(manifest_path, version),
         Ecosystem::Go => GoAdapter::write_version(manifest_path, version),
+        Ecosystem::Swift => SwiftAdapter::write_version(manifest_path, version),
     }
 }
 
@@ -195,6 +208,7 @@ pub fn update_dependency_versions(
         Ecosystem::Rust => RustAdapter::update_all_dependency_versions(packages, root, updates),
         Ecosystem::Python => PythonAdapter::update_all_dependency_versions(packages, root, updates),
         Ecosystem::Go => GoAdapter::update_all_dependency_versions(packages, root, updates),
+        Ecosystem::Swift => SwiftAdapter::update_all_dependency_versions(packages, root, updates),
     }
 }
 
@@ -203,6 +217,7 @@ pub fn is_published(ecosystem: Ecosystem, name: &str, version: &Version) -> Resu
         Ecosystem::Rust => RustAdapter::is_published(name, version),
         Ecosystem::Python => PythonAdapter::is_published(name, version),
         Ecosystem::Go => GoAdapter::is_published(name, version),
+        Ecosystem::Swift => SwiftAdapter::is_published(name, version),
     }
 }
 
@@ -216,6 +231,7 @@ pub fn publish(
         Ecosystem::Rust => RustAdapter::publish(pkg, dry_run, registry),
         Ecosystem::Python => PythonAdapter::publish(pkg, dry_run, registry),
         Ecosystem::Go => GoAdapter::publish(pkg, dry_run, registry),
+        Ecosystem::Swift => SwiftAdapter::publish(pkg, dry_run, registry),
     }
 }
 
@@ -224,5 +240,6 @@ pub fn tag_name(ecosystem: Ecosystem, pkg: &Package) -> String {
         Ecosystem::Rust => RustAdapter::tag_name(pkg),
         Ecosystem::Python => PythonAdapter::tag_name(pkg),
         Ecosystem::Go => GoAdapter::tag_name(pkg),
+        Ecosystem::Swift => SwiftAdapter::tag_name(pkg),
     }
 }

--- a/src/ecosystems/swift.rs
+++ b/src/ecosystems/swift.rs
@@ -1,0 +1,288 @@
+use crate::ecosystems::{Ecosystem, EcosystemAdapter, Package, PublishResult};
+use crate::error::{Error, Result};
+use regex::Regex;
+use semver::Version;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Adapter for Swift Package Manager packages.
+///
+/// SwiftPM versions are distributed through git tags, not stored in
+/// `Package.swift`. Like the Go adapter, we persist the currently planned
+/// version in a manifest comment so version bumps survive between CI steps:
+///
+/// ```swift
+/// // changelogs:version 1.2.3
+/// // swift-tools-version: 5.10
+/// ```
+///
+/// The adapter currently supports a single root `Package.swift`.
+pub struct SwiftAdapter;
+
+const VERSION_COMMENT_PREFIX: &str = "// changelogs:version ";
+
+impl EcosystemAdapter for SwiftAdapter {
+    fn ecosystem() -> Ecosystem {
+        Ecosystem::Swift
+    }
+
+    fn discover(root: &Path) -> Result<Vec<Package>> {
+        let manifest_path = root.join("Package.swift");
+        if !manifest_path.exists() {
+            return Err(Error::SwiftPackageNotFound(format!(
+                "No Package.swift found at {}",
+                root.display()
+            )));
+        }
+
+        let content = fs::read_to_string(&manifest_path)?;
+        let name = parse_package_name(&content).ok_or_else(|| {
+            Error::SwiftPackageNotFound(format!(
+                "Package.swift at {} has no Package(name:) value",
+                manifest_path.display()
+            ))
+        })?;
+        let version = read_version_from_content(&content)
+            .or_else(|| latest_git_tag_version(root))
+            .unwrap_or_else(|| Version::new(0, 0, 0));
+        let dependencies = parse_dependencies(&content);
+
+        Ok(vec![Package {
+            name,
+            version,
+            path: root.to_path_buf(),
+            manifest_path,
+            dependencies,
+        }])
+    }
+
+    fn read_version(manifest_path: &Path) -> Result<Version> {
+        let content = fs::read_to_string(manifest_path)?;
+        if let Some(version) = read_version_from_content(&content) {
+            return Ok(version);
+        }
+
+        let root = manifest_path
+            .parent()
+            .ok_or_else(|| Error::VersionNotFound(manifest_path.display().to_string()))?;
+        Ok(latest_git_tag_version(root).unwrap_or_else(|| Version::new(0, 0, 0)))
+    }
+
+    fn write_version(manifest_path: &Path, version: &Version) -> Result<()> {
+        let content = fs::read_to_string(manifest_path)?;
+        fs::write(manifest_path, upsert_version_comment(&content, version))?;
+        Ok(())
+    }
+
+    fn update_dependency_version(
+        manifest_path: &Path,
+        dep_name: &str,
+        new_version: &Version,
+    ) -> Result<bool> {
+        let content = fs::read_to_string(manifest_path)?;
+        let (updated, modified) = rewrite_dependency_versions(&content, dep_name, new_version);
+        if modified {
+            fs::write(manifest_path, updated)?;
+        }
+        Ok(modified)
+    }
+
+    fn is_published(_name: &str, version: &Version) -> Result<bool> {
+        // `0.0.0` is the implicit baseline when no changelogs version comment or
+        // git tag exists. Treat it as already published so `publish` does not
+        // create a meaningless bootstrap tag.
+        Ok(*version == Version::new(0, 0, 0))
+    }
+
+    fn publish(_pkg: &Package, _dry_run: bool, _registry: Option<&str>) -> Result<PublishResult> {
+        // SwiftPM packages are published by pushing git tags. The shared publish
+        // flow creates those tags after this adapter reports success.
+        Ok(PublishResult::Success)
+    }
+
+    fn tag_name(pkg: &Package) -> String {
+        format!("v{}", pkg.version)
+    }
+}
+
+impl SwiftAdapter {
+    pub fn update_all_dependency_versions(
+        packages: &[Package],
+        _root: &Path,
+        updates: &HashMap<String, Version>,
+    ) -> Result<()> {
+        for pkg in packages {
+            for (dep, new_version) in updates {
+                Self::update_dependency_version(&pkg.manifest_path, dep, new_version)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn parse_package_name(content: &str) -> Option<String> {
+    let re = Regex::new(r#"Package\s*\(\s*name\s*:\s*"([^"]+)""#).ok()?;
+    re.captures(content)
+        .and_then(|captures| captures.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+fn read_version_from_content(content: &str) -> Option<Version> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(VERSION_COMMENT_PREFIX) {
+            if let Ok(version) = rest.trim().parse::<Version>() {
+                return Some(version);
+            }
+        }
+    }
+    None
+}
+
+fn upsert_version_comment(content: &str, version: &Version) -> String {
+    let new_line = format!("{}{}", VERSION_COMMENT_PREFIX, version);
+    let mut found = false;
+    let mut out = Vec::with_capacity(content.lines().count() + 1);
+
+    for line in content.lines() {
+        if line.trim().starts_with(VERSION_COMMENT_PREFIX) {
+            out.push(new_line.clone());
+            found = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+
+    if !found {
+        let insert_idx = out
+            .iter()
+            .position(|line| line.trim_start().starts_with("// swift-tools-version:"))
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        out.insert(insert_idx, new_line);
+    }
+
+    let mut joined = out.join("\n");
+    if content.ends_with('\n') && !joined.ends_with('\n') {
+        joined.push('\n');
+    }
+    joined
+}
+
+fn parse_dependencies(content: &str) -> Vec<String> {
+    let re = Regex::new(r#"\.package\s*\(\s*(?:name\s*:\s*"[^"]+"\s*,\s*)?url\s*:\s*"([^"]+)""#)
+        .expect("valid dependency regex");
+    re.captures_iter(content)
+        .filter_map(|captures| captures.get(1))
+        .map(|m| dependency_name_from_url(m.as_str()))
+        .collect()
+}
+
+fn dependency_name_from_url(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/').trim_end_matches(".git");
+    trimmed.rsplit('/').next().unwrap_or(trimmed).to_string()
+}
+
+fn rewrite_dependency_versions(
+    content: &str,
+    dep_name: &str,
+    new_version: &Version,
+) -> (String, bool) {
+    let mut modified = false;
+    let target = format!(r#"$1"{}""#, new_version);
+    let package_re = Regex::new(r#"\.package\s*\([^)]*\)"#).expect("valid package regex");
+    let version_re =
+        Regex::new(r#"(,\s*(?:from|exact)\s*:\s*)"[^"]+""#).expect("valid version regex");
+
+    let updated = package_re.replace_all(content, |captures: &regex::Captures<'_>| {
+        let package = captures.get(0).expect("whole match").as_str();
+        if !dependency_matches(package, dep_name) || !version_re.is_match(package) {
+            return package.to_string();
+        }
+        modified = true;
+        version_re.replace(package, target.as_str()).to_string()
+    });
+
+    (updated.into_owned(), modified)
+}
+
+fn dependency_matches(package_call: &str, dep_name: &str) -> bool {
+    let url_re = Regex::new(r#"url\s*:\s*"([^"]+)""#).expect("valid url regex");
+    url_re
+        .captures(package_call)
+        .and_then(|captures| captures.get(1))
+        .map(|url| dependency_name_from_url(url.as_str()) == dep_name || url.as_str() == dep_name)
+        .unwrap_or(false)
+}
+
+fn latest_git_tag_version(repo_dir: &Path) -> Option<Version> {
+    let output = Command::new("git")
+        .args(["tag", "--list", "v*", "--sort=-version:refname"])
+        .current_dir(repo_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let candidate = line.trim().trim_start_matches('v');
+        if let Ok(version) = candidate.parse::<Version>() {
+            return Some(version);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_package_name() {
+        let content = r#"let package = Package(
+            name: "TempoKit",
+            products: []
+        )"#;
+        assert_eq!(parse_package_name(content), Some("TempoKit".to_string()));
+    }
+
+    #[test]
+    fn reads_version_comment() {
+        let content = "// changelogs:version 1.2.3\n// swift-tools-version: 5.10\n";
+        assert_eq!(
+            read_version_from_content(content),
+            Some(Version::new(1, 2, 3))
+        );
+    }
+
+    #[test]
+    fn upsert_inserts_after_tools_version() {
+        let content = "// swift-tools-version: 5.10\nimport PackageDescription\n";
+        let updated = upsert_version_comment(content, &Version::new(0, 1, 0));
+        assert!(updated.starts_with("// swift-tools-version: 5.10\n// changelogs:version 0.1.0\n"));
+    }
+
+    #[test]
+    fn parses_dependencies_by_package_url_basename() {
+        let content = r#".package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+            .package(url: "https://github.com/apple/swift-collections", exact: "1.1.0"),"#;
+        assert_eq!(
+            parse_dependencies(content),
+            vec!["swift-log", "swift-collections"]
+        );
+    }
+
+    #[test]
+    fn rewrites_matching_dependency_from_version() {
+        let content = r#".package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+            .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),"#;
+        let (updated, modified) =
+            rewrite_dependency_versions(content, "swift-log", &Version::new(1, 6, 0));
+        assert!(modified);
+        assert!(updated.contains(r#"swift-log.git", from: "1.6.0""#));
+        assert!(updated.contains(r#"swift-collections.git", from: "1.1.0""#));
+    }
+}

--- a/src/ecosystems/swift.rs
+++ b/src/ecosystems/swift.rs
@@ -93,7 +93,11 @@ impl EcosystemAdapter for SwiftAdapter {
         // `0.0.0` is the implicit baseline when no changelogs version comment or
         // git tag exists. Treat it as already published so `publish` does not
         // create a meaningless bootstrap tag.
-        Ok(*version == Version::new(0, 0, 0))
+        if *version == Version::new(0, 0, 0) {
+            return Ok(true);
+        }
+
+        Ok(git_tag_exists(version))
     }
 
     fn publish(_pkg: &Package, _dry_run: bool, _registry: Option<&str>) -> Result<PublishResult> {
@@ -236,6 +240,22 @@ fn latest_git_tag_version(repo_dir: &Path) -> Option<Version> {
     None
 }
 
+fn git_tag_exists(version: &Version) -> bool {
+    let tag = format!("v{}", version);
+    let output = Command::new("git")
+        .args([
+            "rev-parse",
+            "--quiet",
+            "--verify",
+            &format!("refs/tags/{tag}"),
+        ])
+        .output();
+
+    output
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -284,5 +304,10 @@ mod tests {
         assert!(modified);
         assert!(updated.contains(r#"swift-log.git", from: "1.6.0""#));
         assert!(updated.contains(r#"swift-collections.git", from: "1.1.0""#));
+    }
+
+    #[test]
+    fn is_published_skips_bootstrap_v0_0_0() {
+        assert!(SwiftAdapter::is_published("TempoKit", &Version::new(0, 0, 0)).unwrap());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(
-        "could not detect workspace. specify ecosystem with: changelogs --ecosystem <rust|python|go> init"
+        "could not detect workspace. specify ecosystem with: changelogs --ecosystem <rust|python|go|swift> init"
     )]
     NotInWorkspace,
 
@@ -54,6 +54,9 @@ pub enum Error {
 
     #[error("failed to check Go module proxy: {0}")]
     GoProxyCheckFailed(String),
+
+    #[error("Swift package not found: {0}")]
+    SwiftPackageNotFound(String),
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -48,6 +48,7 @@ impl Workspace {
             Ecosystem::Rust => "Cargo.toml",
             Ecosystem::Python => "pyproject.toml",
             Ecosystem::Go => "go.mod",
+            Ecosystem::Swift => "Package.swift",
         };
 
         let mut current = start.to_path_buf();

--- a/tests/fixtures/swift-simple/Package.swift
+++ b/tests/fixtures/swift-simple/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.10
+// changelogs:version 0.4.2
+import PackageDescription
+
+let package = Package(
+    name: "TempoKit",
+    products: [
+        .library(name: "TempoKit", targets: ["TempoKit"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", exact: "1.1.0"),
+    ],
+    targets: [
+        .target(name: "TempoKit"),
+    ]
+)

--- a/tests/swift_adapter.rs
+++ b/tests/swift_adapter.rs
@@ -1,6 +1,7 @@
 use changelogs::ecosystems::{Ecosystem, EcosystemAdapter, SwiftAdapter};
 use semver::Version;
 use std::path::PathBuf;
+use std::process::Command;
 use tempfile::TempDir;
 
 fn fixture_path(name: &str) -> PathBuf {
@@ -122,4 +123,37 @@ fn test_swift_alias_parsing() {
     assert_eq!(Ecosystem::from_str("swift").unwrap(), Ecosystem::Swift);
     assert_eq!(Ecosystem::from_str("swiftpm").unwrap(), Ecosystem::Swift);
     assert_eq!(Ecosystem::from_str("SPM").unwrap(), Ecosystem::Swift);
+}
+
+#[test]
+fn test_swift_is_published_checks_existing_git_tag() {
+    let tmp = TempDir::new().unwrap();
+    let previous_dir = std::env::current_dir().unwrap();
+
+    run_git(tmp.path(), &["init"]);
+    run_git(tmp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(tmp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(tmp.path().join("README.md"), "test\n").unwrap();
+    run_git(tmp.path(), &["add", "README.md"]);
+    run_git(tmp.path(), &["commit", "-m", "init"]);
+    run_git(tmp.path(), &["tag", "v0.4.2"]);
+
+    std::env::set_current_dir(tmp.path()).unwrap();
+    assert!(SwiftAdapter::is_published("TempoKit", &Version::new(0, 4, 2)).unwrap());
+    assert!(!SwiftAdapter::is_published("TempoKit", &Version::new(0, 4, 3)).unwrap());
+    std::env::set_current_dir(previous_dir).unwrap();
+}
+
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
 }

--- a/tests/swift_adapter.rs
+++ b/tests/swift_adapter.rs
@@ -1,0 +1,125 @@
+use changelogs::ecosystems::{Ecosystem, EcosystemAdapter, SwiftAdapter};
+use semver::Version;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+#[test]
+fn test_swift_discover_fixture() {
+    let root = fixture_path("swift-simple");
+    let packages = SwiftAdapter::discover(&root).unwrap();
+
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name, "TempoKit");
+    assert_eq!(packages[0].version, Version::new(0, 4, 2));
+    assert!(packages[0].manifest_path.ends_with("Package.swift"));
+    assert!(packages[0].dependencies.contains(&"swift-log".to_string()));
+    assert!(
+        packages[0]
+            .dependencies
+            .contains(&"swift-collections".to_string())
+    );
+}
+
+#[test]
+fn test_swift_read_version_from_fixture() {
+    let manifest = fixture_path("swift-simple").join("Package.swift");
+    let version = SwiftAdapter::read_version(&manifest).unwrap();
+    assert_eq!(version, Version::new(0, 4, 2));
+}
+
+#[test]
+fn test_swift_write_version_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let manifest = tmp.path().join("Package.swift");
+    std::fs::write(
+        &manifest,
+        r#"// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(name: "TempoKit")
+"#,
+    )
+    .unwrap();
+
+    let v0 = SwiftAdapter::read_version(&manifest).unwrap();
+    assert_eq!(v0, Version::new(0, 0, 0));
+
+    SwiftAdapter::write_version(&manifest, &Version::new(0, 5, 0)).unwrap();
+    let v1 = SwiftAdapter::read_version(&manifest).unwrap();
+    assert_eq!(v1, Version::new(0, 5, 0));
+
+    let on_disk = std::fs::read_to_string(&manifest).unwrap();
+    assert!(on_disk.contains("// changelogs:version 0.5.0"));
+    assert!(on_disk.contains("// swift-tools-version: 5.10"));
+    assert!(on_disk.contains(r#"Package(name: "TempoKit")"#));
+}
+
+#[test]
+fn test_swift_update_dependency_version() {
+    let tmp = TempDir::new().unwrap();
+    let manifest = tmp.path().join("Package.swift");
+    std::fs::write(
+        &manifest,
+        r#"// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "TempoKit",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", exact: "1.1.0"),
+    ]
+)
+"#,
+    )
+    .unwrap();
+
+    let modified =
+        SwiftAdapter::update_dependency_version(&manifest, "swift-log", &Version::new(1, 6, 0))
+            .unwrap();
+    assert!(modified);
+
+    let content = std::fs::read_to_string(&manifest).unwrap();
+    assert!(content.contains(r#"swift-log.git", from: "1.6.0""#));
+    assert!(content.contains(r#"swift-collections.git", exact: "1.1.0""#));
+}
+
+#[test]
+fn test_swift_tag_name_v_prefixed() {
+    let root = fixture_path("swift-simple");
+    let pkg = &SwiftAdapter::discover(&root).unwrap()[0];
+    assert_eq!(SwiftAdapter::tag_name(pkg), "v0.4.2");
+}
+
+#[test]
+fn test_swift_ecosystem_detection() {
+    let swift_dir = TempDir::new().unwrap();
+    std::fs::write(
+        swift_dir.path().join("Package.swift"),
+        r#"// swift-tools-version: 5.10
+import PackageDescription
+let package = Package(name: "TempoKit")
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        changelogs::ecosystems::detect_ecosystem(swift_dir.path()),
+        Some(Ecosystem::Swift)
+    );
+}
+
+#[test]
+fn test_swift_alias_parsing() {
+    use std::str::FromStr;
+    assert_eq!(Ecosystem::from_str("swift").unwrap(), Ecosystem::Swift);
+    assert_eq!(Ecosystem::from_str("swiftpm").unwrap(), Ecosystem::Swift);
+    assert_eq!(Ecosystem::from_str("SPM").unwrap(), Ecosystem::Swift);
+}


### PR DESCRIPTION
## Summary
- add a SwiftPM ecosystem adapter for root Package.swift projects
- persist SwiftPM versions with a changelogs comment and use v-prefixed git tags for publishing
- add SwiftPM fixture/tests and README ecosystem notes

## Tests
- cargo test