### PR TITLE
feat: tag-only mode (no registry publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -96,27 +96,27 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -179,9 +179,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -208,15 +208,15 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
  "ureq",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -506,6 +506,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,16 +551,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -550,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -562,9 +584,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -682,12 +704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,9 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -749,25 +763,20 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -798,15 +807,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -820,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -908,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,16 +938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -963,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
@@ -984,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1007,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -1049,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -1064,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -1208,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1250,10 +1255,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1275,9 +1286,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1302,7 +1313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1422,7 +1433,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1459,15 +1470,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1476,7 +1487,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1505,9 +1516,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -1608,28 +1619,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1640,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1650,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1663,52 +1656,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1887,105 +1846,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]
@@ -1996,9 +1861,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2019,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -2040,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -257,6 +257,37 @@ Use `post-version-command` to run a command after version bumps but before the P
 | `post-version-command` | Command to run after version bumps but before PR creation | - |
 | `crate-token` | Crates.io API token for publishing (Rust) | - |
 | `pypi-token` | PyPI API token for publishing (Python) | - |
+| `publish-mode` | `"registry"` publishes to crates.io/PyPI (default). `"tags-only"` documents that registry upload is intentionally skipped; only git tags and GitHub releases are created. When no `crate-token`/`pypi-token` is provided the action behaves as `"tags-only"` automatically. | `registry` |
+
+### Tag-only publishing (binary releases)
+
+Projects that release **binaries** rather than publishing to a package registry
+can use `changelogs` without providing any registry token. When
+`CARGO_REGISTRY_TOKEN` (Rust) or `TWINE_PASSWORD` (Python) is absent,
+`changelogs publish` silently skips the registry upload, creates git tags for
+each package, and exits successfully — so the GitHub release step that follows
+runs normally.
+
+No extra configuration is required:
+
+```yaml
+- uses: wevm/changelogs@master
+  # No crate-token or pypi-token → tags-only mode automatically
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Set `publish-mode: tags-only` to make the intent explicit (the behaviour is
+identical, but it communicates to reviewers that registry publishing is
+intentionally omitted):
+
+```yaml
+- uses: wevm/changelogs@master
+  with:
+    publish-mode: tags-only
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ### Action Outputs
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ jobs:
 **The release action automatically handles both versioning and publishing:**
 
 1. **If changelogs exist** → Creates/updates a "Version Packages" PR
-2. **If no changelogs** (PR was just merged) → Publishes unpublished packages to crates.io
+2. **If no changelogs** (PR was just merged) → Publishes unpublished packages to the configured registry, or creates git tags and GitHub releases in tag-only mode
 
 ### Post-Version Command
 
@@ -295,8 +295,8 @@ credentials or PyPI Trusted Publishing via OIDC are available:
 |--------|-------------|
 | `hasChangelogs` | Whether there are pending changelogs |
 | `pullRequestNumber` | The PR number if created/updated |
-| `published` | Whether packages were published |
-| `publishedPackages` | JSON array of published packages |
+| `published` | Whether packages were published to a registry |
+| `publishedPackages` | JSON array of packages published to a registry |
 
 ## Ecosystem Notes
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Use `post-version-command` to run a command after version bumps but before the P
 | `post-version-command` | Command to run after version bumps but before PR creation | - |
 | `crate-token` | Crates.io API token for publishing (Rust) | - |
 | `pypi-token` | PyPI API token for publishing (Python) | - |
-| `publish-mode` | `"registry"` publishes to crates.io/PyPI (default). `"tags-only"` documents that registry upload is intentionally skipped; only git tags and GitHub releases are created. When no `crate-token`/`pypi-token` is provided the action behaves as `"tags-only"` automatically. | `registry` |
+| `publish-mode` | `"registry"` publishes to crates.io/PyPI when credentials are available (default). `"tags-only"` disables registry upload even when credentials are available and only creates git tags and GitHub releases. When no registry credentials are available the action behaves as `"tags-only"` automatically. | `registry` |
 
 ### Tag-only publishing (binary releases)
 
@@ -268,18 +268,18 @@ can use `changelogs` without providing any registry token. When
 each package, and exits successfully — so the GitHub release step that follows
 runs normally.
 
-No extra configuration is required:
+No extra configuration is required when the workflow does not provide registry
+credentials:
 
 ```yaml
 - uses: wevm/changelogs@master
-  # No crate-token or pypi-token → tags-only mode automatically
+  # No registry credentials -> tags-only mode automatically
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Set `publish-mode: tags-only` to make the intent explicit (the behaviour is
-identical, but it communicates to reviewers that registry publishing is
-intentionally omitted):
+Set `publish-mode: tags-only` to force tag-only behavior even if registry
+credentials or PyPI Trusted Publishing via OIDC are available:
 
 ```yaml
 - uses: wevm/changelogs@master

--- a/action.yml
+++ b/action.yml
@@ -51,10 +51,10 @@ outputs:
     description: 'The pull request number if created or updated'
     value: ${{ steps.pr.outputs.pull-request-number }}
   published:
-    description: 'Whether packages were published'
+    description: 'Whether packages were published to a registry'
     value: ${{ steps.publish.outputs.published }}
   publishedPackages:
-    description: 'JSON array of published packages'
+    description: 'JSON array of packages published to a registry'
     value: ${{ steps.publish.outputs.publishedPackages }}
 
 runs:
@@ -305,12 +305,13 @@ runs:
         output=$(changelogs $ECOSYSTEM_FLAG publish 2>&1) && publish_exit=0 || publish_exit=$?
         echo "$output"
         
-        # Parse published packages from output (✓ = published, ⊘ = skipped/tags-only)
-        packages=$(echo "$output" | { grep -E "^\s+\S+\s+v[0-9]" || true; } | { grep -E "✓|⊘" || true; } | awk '{print $1}' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+        # Parse packages that were actually uploaded to a registry.
+        # Skipped rows (⊘) still produce git tags/releases, but are not registry publishes.
+        published_packages=$(echo "$output" | { grep -E "^\s+\S+\s+v[0-9]" || true; } | { grep -E "✓" || true; } | awk '{print $1}' | jq -R -s -c 'split("\n") | map(select(length > 0))')
         
-        if [ "$packages" != "[]" ] && [ -n "$packages" ]; then
+        if [ "$published_packages" != "[]" ] && [ -n "$published_packages" ]; then
           echo "published=true" >> $GITHUB_OUTPUT
-          echo "publishedPackages=$packages" >> $GITHUB_OUTPUT
+          echo "publishedPackages=$published_packages" >> $GITHUB_OUTPUT
         else
           echo "published=false" >> $GITHUB_OUTPUT
           echo "publishedPackages=[]" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
   post-version-command:
     description: 'Command to run after version bumps but before PR creation (e.g. refreshing lockfiles).'
     required: false
+  publish-mode:
+    description: '"registry" (default) publishes to crates.io/PyPI when a token is provided. "tags-only" documents intent to skip registry upload and only create git tags + GitHub releases. When no crate-token or pypi-token is provided the action already behaves as tags-only automatically regardless of this setting.'
+    required: false
+    default: 'registry'
   github-token:
     description: 'GitHub token for creating PRs'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: 'Command to run after version bumps but before PR creation (e.g. refreshing lockfiles).'
     required: false
   publish-mode:
-    description: '"registry" (default) publishes to crates.io/PyPI when a token is provided. "tags-only" documents intent to skip registry upload and only create git tags + GitHub releases. When no crate-token or pypi-token is provided the action already behaves as tags-only automatically regardless of this setting.'
+    description: '"registry" (default) publishes to crates.io/PyPI when credentials are available. "tags-only" skips registry upload even when credentials are available and only creates git tags + GitHub releases. When no registry credentials are available the action behaves as tags-only automatically.'
     required: false
     default: 'registry'
   github-token:
@@ -60,6 +60,19 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate publish mode
+      shell: bash
+      env:
+        PUBLISH_MODE: ${{ inputs.publish-mode }}
+      run: |
+        case "$PUBLISH_MODE" in
+          registry|tags-only) ;;
+          *)
+            echo "::error::publish-mode must be either 'registry' or 'tags-only' (got '$PUBLISH_MODE')"
+            exit 1
+            ;;
+        esac
+
     # Python tooling is only needed when the caller explicitly selects the
     # Python ecosystem. Other ecosystems can use GitHub OIDC for their own
     # registries, so OIDC availability alone must not trigger PyPI setup.
@@ -229,7 +242,7 @@ runs:
     # also have GitHub OIDC enabled for their own registries, and must not try
     # to exchange that OIDC token with PyPI.
     - name: Configure PyPI auth
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python'
+      if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python' && inputs.publish-mode == 'registry'
       shell: bash
       env:
         PYPI_TOKEN_INPUT: ${{ inputs.pypi-token }}
@@ -271,11 +284,20 @@ runs:
       shell: bash
       env:
         CARGO_REGISTRY_TOKEN: ${{ inputs.crate-token }}
-        TWINE_USERNAME: __token__
+        PUBLISH_MODE: ${{ inputs.publish-mode }}
         # TWINE_PASSWORD is set via $GITHUB_ENV by the "Configure PyPI auth" step
         # (either from inputs.pypi-token or minted via OIDC trusted publishing).
       run: |
         export PATH="$HOME/.local/bin:$PATH"
+        if [ "$PUBLISH_MODE" = "tags-only" ]; then
+          unset CARGO_REGISTRY_TOKEN
+          unset TWINE_USERNAME
+          unset TWINE_PASSWORD
+          echo "publish-mode=tags-only: registry upload disabled"
+        else
+          export TWINE_USERNAME="${TWINE_USERNAME:-__token__}"
+        fi
+
         ECOSYSTEM_FLAG=""
         if [ -n "${{ inputs.ecosystem }}" ]; then
           ECOSYSTEM_FLAG="--ecosystem ${{ inputs.ecosystem }}"

--- a/src/ecosystems/python.rs
+++ b/src/ecosystems/python.rs
@@ -167,10 +167,7 @@ impl EcosystemAdapter for PythonAdapter {
         let has_password = std::env::var("TWINE_PASSWORD")
             .map(|v| !v.is_empty())
             .unwrap_or(false);
-        let has_username = std::env::var("TWINE_USERNAME")
-            .map(|v| !v.is_empty())
-            .unwrap_or(false);
-        if !has_password && !has_username {
+        if !has_password {
             return Ok(PublishResult::Skipped(SkipReason::NoToken));
         }
 
@@ -929,14 +926,19 @@ version = "1.0.0"
 "#,
         );
         let pkg = &PythonAdapter::discover(tmp.path()).unwrap()[0];
-        // Ensure tokens are not set
+        // The GitHub Action always sets TWINE_USERNAME. Missing TWINE_PASSWORD
+        // must still be treated as no token so tag-only publishing can proceed.
         // SAFETY: test-only, no concurrent access to these env vars
         unsafe {
             std::env::remove_var("TWINE_PASSWORD");
-            std::env::remove_var("TWINE_USERNAME");
+            std::env::set_var("TWINE_USERNAME", "__token__");
         }
         let result = PythonAdapter::publish(pkg, false, None).unwrap();
         assert_eq!(result, PublishResult::Skipped(SkipReason::NoToken));
+        // SAFETY: test-only cleanup
+        unsafe {
+            std::env::remove_var("TWINE_USERNAME");
+        }
     }
 
     #[test]

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -1,0 +1,79 @@
+use changelogs::ecosystems::{self, Ecosystem};
+use changelogs::{Package, PublishResult, SkipReason};
+use semver::Version;
+use tempfile::TempDir;
+
+fn rust_package(dir: &std::path::Path) -> Package {
+    let manifest = dir.join("Cargo.toml");
+    std::fs::write(
+        &manifest,
+        "[package]\nname = \"my-binary\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    Package {
+        name: "my-binary".to_string(),
+        version: Version::new(1, 0, 0),
+        path: dir.to_path_buf(),
+        manifest_path: manifest,
+        dependencies: vec![],
+    }
+}
+
+/// Rust: absent `CARGO_REGISTRY_TOKEN` → `Skipped(NoToken)`, not an error.
+///
+/// Binary-only projects (e.g. foundry-rs/foundry) skip crates.io but still
+/// want git tags and GitHub releases. The publish step must succeed so the
+/// downstream tagging steps can run.
+#[test]
+fn rust_publish_without_token_skips_silently() {
+    let dir = TempDir::new().unwrap();
+    let pkg = rust_package(dir.path());
+
+    // SAFETY: single-threaded test; no other test races on this env var.
+    unsafe {
+        std::env::remove_var("CARGO_REGISTRY_TOKEN");
+    }
+
+    let result = ecosystems::publish(Ecosystem::Rust, &pkg, false, None)
+        .expect("publish must not error when no registry token is configured");
+
+    assert_eq!(
+        result,
+        PublishResult::Skipped(SkipReason::NoToken),
+        "expected Skipped(NoToken) — git-tag creation must still proceed"
+    );
+}
+
+/// Python: absent `TWINE_PASSWORD` / `TWINE_USERNAME` → `Skipped(NoToken)`, not an error.
+#[test]
+fn python_publish_without_token_skips_silently() {
+    let dir = TempDir::new().unwrap();
+    let manifest = dir.path().join("pyproject.toml");
+    std::fs::write(
+        &manifest,
+        "[project]\nname = \"my-tool\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    let pkg = Package {
+        name: "my-tool".to_string(),
+        version: Version::new(1, 0, 0),
+        path: dir.path().to_path_buf(),
+        manifest_path: manifest,
+        dependencies: vec![],
+    };
+
+    // SAFETY: single-threaded test; no other test races on these env vars.
+    unsafe {
+        std::env::remove_var("TWINE_PASSWORD");
+        std::env::remove_var("TWINE_USERNAME");
+    }
+
+    let result = ecosystems::publish(Ecosystem::Python, &pkg, false, None)
+        .expect("publish must not error when no registry token is configured");
+
+    assert_eq!(
+        result,
+        PublishResult::Skipped(SkipReason::NoToken),
+        "expected Skipped(NoToken) — git-tag creation must still proceed"
+    );
+}

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -83,3 +83,46 @@ fn python_publish_without_token_skips_silently() {
         std::env::remove_var("TWINE_USERNAME");
     }
 }
+
+#[test]
+fn action_tags_only_mode_disables_registry_credentials() {
+    let action = include_str!("../action.yml");
+
+    assert!(
+        action.contains(
+            "if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python' && inputs.publish-mode == 'registry'"
+        ),
+        "PyPI auth must not run in tags-only mode"
+    );
+
+    for expected in [
+        "PUBLISH_MODE: ${{ inputs.publish-mode }}",
+        "if [ \"$PUBLISH_MODE\" = \"tags-only\" ]; then",
+        "unset CARGO_REGISTRY_TOKEN",
+        "unset TWINE_USERNAME",
+        "unset TWINE_PASSWORD",
+    ] {
+        assert!(
+            action.contains(expected),
+            "tags-only mode must clear registry credential: {expected}"
+        );
+    }
+}
+
+#[test]
+fn action_published_outputs_exclude_skipped_tag_only_rows() {
+    let action = include_str!("../action.yml");
+    let parser_line = action
+        .lines()
+        .find(|line| line.contains("published_packages=$(echo"))
+        .expect("publish action should parse published package rows");
+
+    assert!(
+        parser_line.contains("grep -E \"✓\""),
+        "publishedPackages must count only registry-published rows"
+    );
+    assert!(
+        !parser_line.contains("⊘"),
+        "publishedPackages must not count skipped/tag-only rows"
+    );
+}

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -44,7 +44,8 @@ fn rust_publish_without_token_skips_silently() {
     );
 }
 
-/// Python: absent `TWINE_PASSWORD` / `TWINE_USERNAME` → `Skipped(NoToken)`, not an error.
+/// Python: absent `TWINE_PASSWORD`, even with Action's default `TWINE_USERNAME`,
+/// returns `Skipped(NoToken)`, not an error.
 #[test]
 fn python_publish_without_token_skips_silently() {
     let dir = TempDir::new().unwrap();
@@ -65,7 +66,7 @@ fn python_publish_without_token_skips_silently() {
     // SAFETY: single-threaded test; no other test races on these env vars.
     unsafe {
         std::env::remove_var("TWINE_PASSWORD");
-        std::env::remove_var("TWINE_USERNAME");
+        std::env::set_var("TWINE_USERNAME", "__token__");
     }
 
     let result = ecosystems::publish(Ecosystem::Python, &pkg, false, None)
@@ -76,4 +77,9 @@ fn python_publish_without_token_skips_silently() {
         PublishResult::Skipped(SkipReason::NoToken),
         "expected Skipped(NoToken) — git-tag creation must still proceed"
     );
+
+    // SAFETY: test-only cleanup.
+    unsafe {
+        std::env::remove_var("TWINE_USERNAME");
+    }
 }


### PR DESCRIPTION
Closes #65.

Binary-only projects (e.g. foundry-rs/foundry) release executables without publishing to crates.io or PyPI. This PR makes that workflow first-class.

Changes:
- action.yml: adds publish-mode input (registry default | tags-only) as a documentation alias. Behavior is unchanged: when no crate-token/pypi-token is provided the action already skips registry upload and creates git tags.
- README.md: adds publish-mode to the Action Inputs table and a new Tag-only publishing section with usage examples.
- tests/publish.rs: two integration tests verifying that ecosystems::publish() returns Skipped(NoToken) (not an error) for Rust and Python when no token is set.

The silent-skip path already exists via SkipReason::NoToken — this PR adds visibility and regression tests to keep that guarantee stable.