### PR TITLE
feat: multi-branch release PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,33 @@ Use `post-version-command` to run a command after version bumps but before the P
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `branch` | Branch name for the version PR | `changelog-release/main` |
+| `branch` | Branch name for the version PR. Defaults to `changelog-release/{trigger-branch}`, enabling independent release PRs per branch. | `changelog-release/{trigger-branch}` |
 | `commit` | Commit message for version bump | `Version Packages` |
 | `conventional-commit` | Use conventional commit format | `false` |
 | `post-version-command` | Command to run after version bumps but before PR creation | - |
 | `crate-token` | Crates.io API token for publishing (Rust) | - |
 | `pypi-token` | PyPI API token for publishing (Python) | - |
+
+### Multi-branch releases
+
+To maintain independent release trains per branch (e.g. patch releases on
+`release/v1.5` alongside new features on `master`), no configuration is needed
+— the action automatically creates a separate release PR per trigger branch:
+
+| Trigger branch  | Release PR branch                  |
+|-----------------|------------------------------------|
+| master          | changelog-release/master           |
+| release/v1.5    | changelog-release/release/v1.5     |
+| release/v2.0    | changelog-release/release/v2.0     |
+
+Changelog entries on each branch are independent. To override the release PR
+branch name, set the `branch` input explicitly:
+
+```yaml
+- uses: wevm/changelogs@master
+  with:
+    branch: my-custom-release-branch
+```
 
 ### Action Outputs
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
 
 jobs:
   release:
@@ -283,8 +285,9 @@ immediately.
 ### Multi-branch releases
 
 To maintain independent release trains per branch (e.g. patch releases on
-`release/v1.5` alongside new features on `master`), no configuration is needed
-— the action automatically creates a separate release PR per trigger branch:
+`release/v1.5` alongside new features on `master`), configure your release
+workflow to run on each release branch. The action then automatically creates a
+separate release PR per trigger branch:
 
 | Trigger branch  | Release PR branch                  |
 |-----------------|------------------------------------|

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,8 @@ inputs:
     required: false
     default: 'false'
   branch:
-    description: 'Branch name for the version PR'
+    description: 'Branch name for the version PR. Defaults to changelog-release/{trigger-branch}, enabling independent release PRs per branch.'
     required: false
-    default: 'changelog-release/main'
   post-version-command:
     description: 'Command to run after version bumps but before PR creation (e.g. refreshing lockfiles).'
     required: false
@@ -93,6 +92,18 @@ runs:
           echo "hasChangelogs=false" >> $GITHUB_OUTPUT
           echo "No pending changelogs"
         fi
+
+    - name: Resolve release branch
+      id: resolve-branch
+      shell: bash
+      run: |
+        RELEASE_BRANCH="${{ inputs.branch }}"
+        if [ -z "$RELEASE_BRANCH" ]; then
+          REF="${{ github.ref_name }}"
+          REF="${REF#refs/heads/}"
+          RELEASE_BRANCH="changelog-release/${REF}"
+        fi
+        echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
 
     # Version mode: Create PR when changelogs exist
     - name: Setup Git user
@@ -197,7 +208,7 @@ runs:
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ inputs.github-token }}
-        branch: ${{ inputs.branch }}
+        branch: ${{ steps.resolve-branch.outputs.release_branch }}
         title: ${{ steps.version.outputs.title }}
         body-path: ${{ steps.body.outputs.body-file }}
         base: ${{ github.ref_name }}


### PR DESCRIPTION
Closes #64.

Patch releases on maintenance branches (e.g. release/v1.5) were impossible because the release PR branch was always hardcoded to changelog-release/main, meaning every push from any branch competed for the same PR.

Changes:
- action.yml: branch input default removed; a new 'Resolve release branch' step (id: resolve-branch) computes changelog-release/{sanitized-ref_name} when branch is not set. The single use of inputs.branch in the Create or update PR step is replaced with steps.resolve-branch.outputs.release_branch.
- README.md: branch row in Action Inputs table updated to show the dynamic default; new 'Multi-branch releases' section added after 'Tag-only publishing' with a mapping table and override example.

No Rust source files were changed.