### PR TITLE
feat: support prerelease versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Or download directly from [GitHub Releases](https://github.com/wevm/changelogs/r
 | `add --ai "<command>"` | Generate changelog using AI (see [Supported AI Providers](#supported-ai-providers)) |
 | `status` | Show pending changelogs and releases |
 | `version` | Apply version bumps and update changelogs |
+| `version --prerelease rc` | Apply prerelease bumps like `1.6.0-rc1`, then `1.6.0-rc2` |
 | `publish` | Publish unpublished packages to crates.io |
 
 ## Configuration
@@ -247,6 +248,21 @@ Use `post-version-command` to run a command after version bumps but before the P
     post-version-command: 'cargo metadata --format-version=1 > /dev/null'
 ```
 
+### Prerelease Versioning
+
+Use `prerelease` to create release candidate PRs before a stable release:
+
+```yaml
+- uses: wevm/changelogs@master
+  with:
+    prerelease: rc
+```
+
+This runs `changelogs version --prerelease rc`, creating versions like
+`1.6.0-rc1` and incrementing an existing `1.6.0-rc1` to `1.6.0-rc2`.
+Running `changelogs version` without `--prerelease` promotes an existing
+prerelease version to its stable version, such as `1.6.0`.
+
 ### Action Inputs
 
 | Input | Description | Default |
@@ -254,6 +270,7 @@ Use `post-version-command` to run a command after version bumps but before the P
 | `branch` | Branch name for the version PR | `changelog-release/main` |
 | `commit` | Commit message for version bump | `Version Packages` |
 | `conventional-commit` | Use conventional commit format | `false` |
+| `prerelease` | Prerelease identifier for release candidates, such as `rc` | - |
 | `post-version-command` | Command to run after version bumps but before PR creation | - |
 | `crate-token` | Crates.io API token for publishing (Rust) | - |
 | `pypi-token` | PyPI API token for publishing (Python) | - |

--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ This runs `changelogs version --prerelease rc`, creating versions like
 Running `changelogs version` without `--prerelease` promotes an existing
 prerelease version to its stable version, such as `1.6.0`.
 
+In the GitHub Action, leave `prerelease` unset for the stable release workflow.
+When there are no pending changelog files but package versions are still
+prereleases, the action opens a stable-promotion PR instead of publishing
+immediately.
+
 ### Action Inputs
 
 | Input | Description | Default |

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
     description: 'Use conventional commit format (chore: prefix)'
     required: false
     default: 'false'
+  prerelease:
+    description: 'Prerelease identifier for release candidates (e.g. rc creates rc1, rc2).'
+    required: false
   branch:
     description: 'Branch name for the version PR'
     required: false
@@ -106,13 +109,20 @@ runs:
       if: steps.check.outputs.hasChangelogs == 'true'
       id: version
       shell: bash
+      env:
+        ECOSYSTEM_INPUT: ${{ inputs.ecosystem }}
+        PRERELEASE_INPUT: ${{ inputs.prerelease }}
       run: |
         export PATH="$HOME/.local/bin:$PATH"
-        ECOSYSTEM_FLAG=""
-        if [ -n "${{ inputs.ecosystem }}" ]; then
-          ECOSYSTEM_FLAG="--ecosystem ${{ inputs.ecosystem }}"
+        CMD=(changelogs)
+        if [ -n "$ECOSYSTEM_INPUT" ]; then
+          CMD+=(--ecosystem "$ECOSYSTEM_INPUT")
         fi
-        output=$(changelogs $ECOSYSTEM_FLAG version 2>&1) && version_exit=0 || version_exit=$?
+        CMD+=(version)
+        if [ -n "$PRERELEASE_INPUT" ]; then
+          CMD+=(--prerelease "$PRERELEASE_INPUT")
+        fi
+        output=$("${CMD[@]}" 2>&1) && version_exit=0 || version_exit=$?
         echo "$output"
         if [ $version_exit -ne 0 ]; then
           echo "::error::changelogs version failed with exit code $version_exit"
@@ -128,9 +138,10 @@ runs:
           fi
         fi
         
-        # Extract versions from output (e.g., "tempo-common 0.1.4 → 0.1.5" -> "tempo-common@0.1.5")
-        all_versions=$(echo "$output" | grep -oE '[a-zA-Z0-9_-]+ [0-9]+\.[0-9]+\.[0-9]+ → [0-9]+\.[0-9]+\.[0-9]+' | sed 's/ .* → /@/')
-        count=$(echo "$all_versions" | grep -c . || echo 0)
+        # Extract versions from output (e.g., "tempo-common 0.1.4 → 0.1.5-rc1" -> "tempo-common@0.1.5-rc1")
+        semver_re='[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?'
+        all_versions=$(echo "$output" | grep -oE "[^[:space:]]+ $semver_re → $semver_re" | sed 's/ .* → /@/')
+        count=$(echo "$all_versions" | grep -c . || true)
         
         if [ "$changelog_format" = "root" ]; then
           # Root format: all packages share one version, use v{version}

--- a/action.yml
+++ b/action.yml
@@ -88,25 +88,45 @@ runs:
     - name: Check for changelogs
       id: check
       shell: bash
+      env:
+        ECOSYSTEM_INPUT: ${{ inputs.ecosystem }}
+        PRERELEASE_INPUT: ${{ inputs.prerelease }}
       run: |
+        has_changelogs=false
         if [ -d ".changelog" ] && [ "$(find .changelog -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)" ]; then
-          echo "hasChangelogs=true" >> $GITHUB_OUTPUT
+          has_changelogs=true
           echo "Found pending changelogs"
         else
-          echo "hasChangelogs=false" >> $GITHUB_OUTPUT
           echo "No pending changelogs"
         fi
+        echo "hasChangelogs=$has_changelogs" >> $GITHUB_OUTPUT
 
-    # Version mode: Create PR when changelogs exist
+        has_prereleases=false
+        if [ "$has_changelogs" = "false" ] && [ -z "$PRERELEASE_INPUT" ]; then
+          CMD=(changelogs)
+          if [ -n "$ECOSYSTEM_INPUT" ]; then
+            CMD+=(--ecosystem "$ECOSYSTEM_INPUT")
+          fi
+          CMD+=(version --dry-run)
+
+          output=$("${CMD[@]}" 2>&1) && version_exit=0 || version_exit=$?
+          if [ $version_exit -eq 0 ] && echo "$output" | grep -Eq '[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*(\+[0-9A-Za-z][0-9A-Za-z.-]*)? → [0-9]+\.[0-9]+\.[0-9]+'; then
+            has_prereleases=true
+            echo "Found prerelease versions to promote"
+          fi
+        fi
+        echo "hasPrereleases=$has_prereleases" >> $GITHUB_OUTPUT
+
+    # Version mode: Create PR when changelogs exist, or when prereleases can be promoted to stable.
     - name: Setup Git user
-      if: steps.check.outputs.hasChangelogs == 'true'
+      if: steps.check.outputs.hasChangelogs == 'true' || steps.check.outputs.hasPrereleases == 'true'
       shell: bash
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
     - name: Run version command
-      if: steps.check.outputs.hasChangelogs == 'true'
+      if: steps.check.outputs.hasChangelogs == 'true' || steps.check.outputs.hasPrereleases == 'true'
       id: version
       shell: bash
       env:
@@ -177,12 +197,12 @@ runs:
         fi
 
     - name: Run post-version command
-      if: steps.check.outputs.hasChangelogs == 'true' && inputs.post-version-command != ''
+      if: (steps.check.outputs.hasChangelogs == 'true' || steps.check.outputs.hasPrereleases == 'true') && inputs.post-version-command != ''
       shell: bash
       run: ${{ inputs.post-version-command }}
 
     - name: Generate PR body
-      if: steps.check.outputs.hasChangelogs == 'true'
+      if: steps.check.outputs.hasChangelogs == 'true' || steps.check.outputs.hasPrereleases == 'true'
       id: body
       shell: bash
       run: |
@@ -203,7 +223,7 @@ runs:
         echo "body-file=/tmp/pr-body.md" >> $GITHUB_OUTPUT
 
     - name: Create or update PR
-      if: steps.check.outputs.hasChangelogs == 'true'
+      if: steps.check.outputs.hasChangelogs == 'true' || steps.check.outputs.hasPrereleases == 'true'
       id: pr
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
@@ -215,10 +235,10 @@ runs:
         commit-message: ${{ inputs.commit || steps.version.outputs.commit-msg }}
         delete-branch: true
 
-    # Publish mode: Publish when no changelogs (PR was just merged)
+    # Publish mode: Publish when no changelogs or stable-promotion PR are needed.
     # Will publish to registry if tokens provided, otherwise just creates git tags
     - name: Setup Git user for tags
-      if: steps.check.outputs.hasChangelogs == 'false'
+      if: steps.check.outputs.hasChangelogs == 'false' && steps.check.outputs.hasPrereleases == 'false'
       shell: bash
       run: |
         git config user.name "github-actions[bot]"
@@ -236,7 +256,7 @@ runs:
     # also have GitHub OIDC enabled for their own registries, and must not try
     # to exchange that OIDC token with PyPI.
     - name: Configure PyPI auth
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python'
+      if: steps.check.outputs.hasChangelogs == 'false' && steps.check.outputs.hasPrereleases == 'false' && inputs.ecosystem == 'python'
       shell: bash
       env:
         PYPI_TOKEN_INPUT: ${{ inputs.pypi-token }}
@@ -273,7 +293,7 @@ runs:
         fi
 
     - name: Publish packages
-      if: steps.check.outputs.hasChangelogs == 'false'
+      if: steps.check.outputs.hasChangelogs == 'false' && steps.check.outputs.hasPrereleases == 'false'
       id: publish
       shell: bash
       env:
@@ -307,12 +327,12 @@ runs:
         fi
 
     - name: Push git tags
-      if: steps.check.outputs.hasChangelogs == 'false' && steps.publish.outcome == 'success'
+      if: steps.check.outputs.hasChangelogs == 'false' && steps.check.outputs.hasPrereleases == 'false' && steps.publish.outcome == 'success'
       shell: bash
       run: git push --follow-tags
 
     - name: Create GitHub releases
-      if: steps.check.outputs.hasChangelogs == 'false' && steps.publish.outcome == 'success'
+      if: steps.check.outputs.hasChangelogs == 'false' && steps.check.outputs.hasPrereleases == 'false' && steps.publish.outcome == 'success'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -26,22 +26,23 @@ pub fn run(dry_run: bool, prerelease: Option<String>, ecosystem: Option<Ecosyste
 
     let changelog_dir = workspace.changelog_dir();
     let changelogs = changelog_entry::read_all(&changelog_dir)?;
-
-    if changelogs.is_empty() {
+    let config = Config::load(&changelog_dir)?;
+    let has_changelogs = !changelogs.is_empty();
+    let release_plan = if has_changelogs {
+        plan::assemble_with_prerelease(&workspace, changelogs.clone(), &config, prerelease.as_ref())
+    } else if prerelease.is_none() {
+        plan::assemble_stable_promotions(&workspace, &config)
+    } else {
         println!("{} No changelogs found", style("ℹ").blue().bold());
         return Ok(());
-    }
-
-    let config = Config::load(&changelog_dir)?;
-    let release_plan = plan::assemble_with_prerelease(
-        &workspace,
-        changelogs.clone(),
-        &config,
-        prerelease.as_ref(),
-    );
+    };
 
     if release_plan.releases.is_empty() {
-        println!("{} No packages to release", style("ℹ").blue().bold());
+        if has_changelogs {
+            println!("{} No packages to release", style("ℹ").blue().bold());
+        } else {
+            println!("{} No changelogs found", style("ℹ").blue().bold());
+        }
         return Ok(());
     }
 
@@ -87,6 +88,15 @@ pub fn run(dry_run: bool, prerelease: Option<String>, ecosystem: Option<Ecosyste
         version_updates.insert(release.name.clone(), release.new_version.clone());
     }
     workspace.update_dependency_versions(&version_updates)?;
+
+    if !has_changelogs {
+        println!(
+            "\n{} {} package(s) updated",
+            style("✓").green().bold(),
+            release_plan.releases.len()
+        );
+        return Ok(());
+    }
 
     println!("{} Updating changelogs...\n", style("→").blue().bold());
 

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -10,7 +10,12 @@ use console::style;
 use semver::Version;
 use std::collections::HashMap;
 
-pub fn run(dry_run: bool, ecosystem: Option<Ecosystem>) -> Result<()> {
+pub fn run(dry_run: bool, prerelease: Option<String>, ecosystem: Option<Ecosystem>) -> Result<()> {
+    let prerelease = prerelease
+        .map(plan::PrereleasePrefix::new)
+        .transpose()
+        .map_err(anyhow::Error::msg)?;
+
     let workspace = Workspace::discover_with_ecosystem(ecosystem).context(
         "could not detect workspace — specify ecosystem with: changelogs --ecosystem <rust|python|go|swift>",
     )?;
@@ -28,7 +33,12 @@ pub fn run(dry_run: bool, ecosystem: Option<Ecosystem>) -> Result<()> {
     }
 
     let config = Config::load(&changelog_dir)?;
-    let release_plan = plan::assemble(&workspace, changelogs.clone(), &config);
+    let release_plan = plan::assemble_with_prerelease(
+        &workspace,
+        changelogs.clone(),
+        &config,
+        prerelease.as_ref(),
+    );
 
     if release_plan.releases.is_empty() {
         println!("{} No packages to release", style("ℹ").blue().bold());

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ enum Commands {
         /// Compute and display the release plan without writing any files
         #[arg(long)]
         dry_run: bool,
+
+        /// Add or increment a prerelease identifier, such as rc for rc1, rc2
+        #[arg(long)]
+        prerelease: Option<String>,
     },
 }
 
@@ -90,7 +94,10 @@ fn main() -> Result<()> {
         }
         Commands::Status { verbose } => cli::status::run(verbose, cli.ecosystem)?,
         Commands::Up => cli::up::run()?,
-        Commands::Version { dry_run } => cli::version::run(dry_run, cli.ecosystem)?,
+        Commands::Version {
+            dry_run,
+            prerelease,
+        } => cli::version::run(dry_run, prerelease, cli.ecosystem)?,
     }
 
     Ok(())

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -3,7 +3,7 @@ use crate::changelog_entry::Changelog;
 use crate::config::{ChangelogFormat, Config, DependentBump};
 use crate::graph::DependencyGraph;
 use crate::workspace::Workspace;
-use semver::Version;
+use semver::{Prerelease, Version};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -22,6 +22,34 @@ pub struct PackageRelease {
     pub changelog_ids: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrereleasePrefix(String);
+
+impl PrereleasePrefix {
+    pub fn new(prefix: impl Into<String>) -> Result<Self, String> {
+        let prefix = prefix.into();
+        if prefix.is_empty() {
+            return Err("prerelease identifier cannot be empty".to_string());
+        }
+
+        let candidate = format!("{}1", prefix);
+        Prerelease::new(&candidate)
+            .map_err(|e| format!("invalid prerelease identifier '{}': {}", prefix, e))?;
+
+        Ok(Self(prefix))
+    }
+
+    fn next(&self, current: Option<&Prerelease>) -> Prerelease {
+        let number = current
+            .and_then(|pre| pre.as_str().strip_prefix(&self.0))
+            .and_then(|suffix| suffix.parse::<u64>().ok())
+            .and_then(|n| n.checked_add(1))
+            .unwrap_or(1);
+
+        Prerelease::new(&format!("{}{number}", self.0)).expect("validated prerelease identifier")
+    }
+}
+
 pub fn bump_version(version: &Version, bump: BumpType) -> Version {
     match bump {
         BumpType::Major => Version::new(version.major + 1, 0, 0),
@@ -30,7 +58,39 @@ pub fn bump_version(version: &Version, bump: BumpType) -> Version {
     }
 }
 
+pub fn bump_version_with_prerelease(
+    version: &Version,
+    bump: BumpType,
+    prerelease: Option<&PrereleasePrefix>,
+) -> Version {
+    match prerelease {
+        Some(prefix) => {
+            let mut next = if version.pre.is_empty() {
+                bump_version(version, bump)
+            } else {
+                Version::new(version.major, version.minor, version.patch)
+            };
+            let current_pre = (!version.pre.is_empty()).then_some(&version.pre);
+            next.pre = prefix.next(current_pre);
+            next
+        }
+        None if !version.pre.is_empty() => {
+            Version::new(version.major, version.minor, version.patch)
+        }
+        None => bump_version(version, bump),
+    }
+}
+
 pub fn assemble(workspace: &Workspace, changelogs: Vec<Changelog>, config: &Config) -> ReleasePlan {
+    assemble_with_prerelease(workspace, changelogs, config, None)
+}
+
+pub fn assemble_with_prerelease(
+    workspace: &Workspace,
+    changelogs: Vec<Changelog>,
+    config: &Config,
+    prerelease: Option<&PrereleasePrefix>,
+) -> ReleasePlan {
     let graph = DependencyGraph::from_workspace(workspace);
 
     let mut bump_map: HashMap<String, BumpType> = HashMap::new();
@@ -142,7 +202,7 @@ pub fn assemble(workspace: &Workspace, changelogs: Vec<Changelog>, config: &Conf
 
     for (name, bump) in bump_map {
         if let Some(package) = workspace.get_package(&name) {
-            let new_version = bump_version(&package.version, bump);
+            let new_version = bump_version_with_prerelease(&package.version, bump, prerelease);
             releases.push(PackageRelease {
                 name: name.clone(),
                 bump,
@@ -259,6 +319,63 @@ mod tests {
         assert_eq!(plan.releases[0].bump, BumpType::Minor);
         assert_eq!(plan.releases[0].old_version, Version::new(1, 0, 0));
         assert_eq!(plan.releases[0].new_version, Version::new(1, 1, 0));
+    }
+
+    #[test]
+    fn test_prerelease_bump_starts_at_one() {
+        let rc = PrereleasePrefix::new("rc").unwrap();
+        let version = bump_version_with_prerelease(
+            &Version::parse("1.5.0").unwrap(),
+            BumpType::Minor,
+            Some(&rc),
+        );
+
+        assert_eq!(version, Version::parse("1.6.0-rc1").unwrap());
+    }
+
+    #[test]
+    fn test_prerelease_bump_increments_existing_suffix() {
+        let rc = PrereleasePrefix::new("rc").unwrap();
+        let version = bump_version_with_prerelease(
+            &Version::parse("1.6.0-rc1").unwrap(),
+            BumpType::Patch,
+            Some(&rc),
+        );
+
+        assert_eq!(version, Version::parse("1.6.0-rc2").unwrap());
+    }
+
+    #[test]
+    fn test_stable_bump_promotes_prerelease() {
+        let version = bump_version_with_prerelease(
+            &Version::parse("1.6.0-rc2").unwrap(),
+            BumpType::Patch,
+            None,
+        );
+
+        assert_eq!(version, Version::parse("1.6.0").unwrap());
+    }
+
+    #[test]
+    fn test_assemble_with_prerelease() {
+        let ws = mock_workspace(vec![mock_package("foo", "1.0.0", vec![])]);
+        let changelogs = vec![make_changelog(
+            "cl1",
+            vec![Release {
+                package: "foo".to_string(),
+                bump: BumpType::Minor,
+            }],
+        )];
+        let config = Config::default();
+        let rc = PrereleasePrefix::new("rc").unwrap();
+
+        let plan = assemble_with_prerelease(&ws, changelogs, &config, Some(&rc));
+
+        assert_eq!(plan.releases.len(), 1);
+        assert_eq!(
+            plan.releases[0].new_version,
+            Version::parse("1.1.0-rc1").unwrap()
+        );
     }
 
     #[test]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -85,6 +85,30 @@ pub fn assemble(workspace: &Workspace, changelogs: Vec<Changelog>, config: &Conf
     assemble_with_prerelease(workspace, changelogs, config, None)
 }
 
+pub fn assemble_stable_promotions(workspace: &Workspace, config: &Config) -> ReleasePlan {
+    let mut releases = workspace
+        .packages
+        .iter()
+        .filter(|pkg| !config.ignore.contains(&pkg.name))
+        .filter(|pkg| !pkg.version.pre.is_empty())
+        .map(|pkg| PackageRelease {
+            name: pkg.name.clone(),
+            bump: BumpType::Patch,
+            old_version: pkg.version.clone(),
+            new_version: Version::new(pkg.version.major, pkg.version.minor, pkg.version.patch),
+            changelog_ids: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    releases.sort_by(|a, b| a.name.cmp(&b.name));
+
+    ReleasePlan {
+        changelogs: Vec::new(),
+        releases,
+        warnings: Vec::new(),
+    }
+}
+
 pub fn assemble_with_prerelease(
     workspace: &Workspace,
     changelogs: Vec<Changelog>,
@@ -354,6 +378,41 @@ mod tests {
         );
 
         assert_eq!(version, Version::parse("1.6.0").unwrap());
+    }
+
+    #[test]
+    fn test_assemble_stable_promotions() {
+        let ws = mock_workspace(vec![
+            mock_package("foo", "1.6.0-rc2", vec![]),
+            mock_package("bar", "1.0.0", vec![]),
+        ]);
+        let config = Config::default();
+
+        let plan = assemble_stable_promotions(&ws, &config);
+
+        assert_eq!(plan.releases.len(), 1);
+        assert_eq!(plan.releases[0].name, "foo");
+        assert_eq!(
+            plan.releases[0].old_version,
+            Version::parse("1.6.0-rc2").unwrap()
+        );
+        assert_eq!(
+            plan.releases[0].new_version,
+            Version::parse("1.6.0").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_assemble_stable_promotions_respects_ignore() {
+        let ws = mock_workspace(vec![mock_package("foo", "1.6.0-rc2", vec![])]);
+        let config = Config {
+            ignore: vec!["foo".to_string()],
+            ..Config::default()
+        };
+
+        let plan = assemble_stable_promotions(&ws, &config);
+
+        assert!(plan.releases.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `changelogs version --prerelease <identifier>` for RC workflows
- increment existing prerelease versions and promote prereleases to stable when run without the flag
- add the GitHub Action `prerelease` input and prerelease-aware version parsing

Closes #63

## Tests
- `cargo test prerelease`
- `cargo test`
- `cargo run -- version --help`
- `git diff --check`