### PR TITLE
feat: tag-only mode (no registry publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
@@ -503,6 +504,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -908,6 +944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1249,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1315,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"

--- a/README.md
+++ b/README.md
@@ -257,6 +257,37 @@ Use `post-version-command` to run a command after version bumps but before the P
 | `post-version-command` | Command to run after version bumps but before PR creation | - |
 | `crate-token` | Crates.io API token for publishing (Rust) | - |
 | `pypi-token` | PyPI API token for publishing (Python) | - |
+| `publish-mode` | `"registry"` publishes to crates.io/PyPI (default). `"tags-only"` documents that registry upload is intentionally skipped; only git tags and GitHub releases are created. When no `crate-token`/`pypi-token` is provided the action behaves as `"tags-only"` automatically. | `registry` |
+
+### Tag-only publishing (binary releases)
+
+Projects that release **binaries** rather than publishing to a package registry
+can use `changelogs` without providing any registry token. When
+`CARGO_REGISTRY_TOKEN` (Rust) or `TWINE_PASSWORD` (Python) is absent,
+`changelogs publish` silently skips the registry upload, creates git tags for
+each package, and exits successfully — so the GitHub release step that follows
+runs normally.
+
+No extra configuration is required:
+
+```yaml
+- uses: wevm/changelogs@master
+  # No crate-token or pypi-token → tags-only mode automatically
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Set `publish-mode: tags-only` to make the intent explicit (the behaviour is
+identical, but it communicates to reviewers that registry publishing is
+intentionally omitted):
+
+```yaml
+- uses: wevm/changelogs@master
+  with:
+    publish-mode: tags-only
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ### Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,19 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate publish mode
+      shell: bash
+      env:
+        PUBLISH_MODE: ${{ inputs.publish-mode }}
+      run: |
+        case "$PUBLISH_MODE" in
+          registry|tags-only) ;;
+          *)
+            echo "::error::Invalid publish-mode '$PUBLISH_MODE'. Expected 'registry' or 'tags-only'."
+            exit 1
+            ;;
+        esac
+
     # Python tooling is only needed when the caller explicitly selects the
     # Python ecosystem. Other ecosystems can use GitHub OIDC for their own
     # registries, so OIDC availability alone must not trigger PyPI setup.

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
   post-version-command:
     description: 'Command to run after version bumps but before PR creation (e.g. refreshing lockfiles).'
     required: false
+  publish-mode:
+    description: '"registry" (default) publishes to crates.io/PyPI when a token is provided. "tags-only" documents intent to skip registry upload and only create git tags + GitHub releases. When no crate-token or pypi-token is provided the action already behaves as tags-only automatically regardless of this setting.'
+    required: false
+    default: 'registry'
   github-token:
     description: 'GitHub token for creating PRs'
     required: false
@@ -225,7 +229,7 @@ runs:
     # also have GitHub OIDC enabled for their own registries, and must not try
     # to exchange that OIDC token with PyPI.
     - name: Configure PyPI auth
-      if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python'
+      if: steps.check.outputs.hasChangelogs == 'false' && inputs.ecosystem == 'python' && inputs.publish-mode != 'tags-only'
       shell: bash
       env:
         PYPI_TOKEN_INPUT: ${{ inputs.pypi-token }}
@@ -266,7 +270,7 @@ runs:
       id: publish
       shell: bash
       env:
-        CARGO_REGISTRY_TOKEN: ${{ inputs.crate-token }}
+        CARGO_REGISTRY_TOKEN: ${{ inputs.publish-mode != 'tags-only' && inputs.crate-token || '' }}
         TWINE_USERNAME: __token__
         # TWINE_PASSWORD is set via $GITHUB_ENV by the "Configure PyPI auth" step
         # (either from inputs.pypi-token or minted via OIDC trusted publishing).

--- a/action.yml
+++ b/action.yml
@@ -315,11 +315,17 @@ runs:
       shell: bash
       env:
         CARGO_REGISTRY_TOKEN: ${{ inputs.publish-mode != 'tags-only' && inputs.crate-token || '' }}
+        PUBLISH_MODE: ${{ inputs.publish-mode }}
         TWINE_USERNAME: __token__
         # TWINE_PASSWORD is set via $GITHUB_ENV by the "Configure PyPI auth" step
         # (either from inputs.pypi-token or minted via OIDC trusted publishing).
       run: |
         export PATH="$HOME/.local/bin:$PATH"
+        if [ "$PUBLISH_MODE" = "tags-only" ]; then
+          unset CARGO_REGISTRY_TOKEN
+          unset TWINE_USERNAME
+          unset TWINE_PASSWORD
+        fi
         ECOSYSTEM_FLAG=""
         if [ -n "${{ inputs.ecosystem }}" ]; then
           ECOSYSTEM_FLAG="--ecosystem ${{ inputs.ecosystem }}"

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use std::env;
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 pub fn run() -> Result<()> {
     let os = detect_os()?;
@@ -30,6 +32,7 @@ pub fn run() -> Result<()> {
         );
     }
 
+    #[cfg(unix)]
     fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755))
         .context("Failed to set executable permissions")?;
 

--- a/src/ecosystems/python.rs
+++ b/src/ecosystems/python.rs
@@ -167,10 +167,7 @@ impl EcosystemAdapter for PythonAdapter {
         let has_password = std::env::var("TWINE_PASSWORD")
             .map(|v| !v.is_empty())
             .unwrap_or(false);
-        let has_username = std::env::var("TWINE_USERNAME")
-            .map(|v| !v.is_empty())
-            .unwrap_or(false);
-        if !has_password && !has_username {
+        if !has_password {
             return Ok(PublishResult::Skipped(SkipReason::NoToken));
         }
 
@@ -543,6 +540,7 @@ impl PythonAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -918,6 +916,7 @@ version = "1.0.0"
     }
 
     #[test]
+    #[serial]
     fn publish_skipped_without_tokens() {
         let tmp = TempDir::new().unwrap();
         create_pyproject(
@@ -929,11 +928,10 @@ version = "1.0.0"
 "#,
         );
         let pkg = &PythonAdapter::discover(tmp.path()).unwrap()[0];
-        // Ensure tokens are not set
-        // SAFETY: test-only, no concurrent access to these env vars
+        // Ensure TWINE_PASSWORD is absent (the action always sets TWINE_USERNAME).
+        // SAFETY: serialized via #[serial]; no concurrent env mutation.
         unsafe {
             std::env::remove_var("TWINE_PASSWORD");
-            std::env::remove_var("TWINE_USERNAME");
         }
         let result = PythonAdapter::publish(pkg, false, None).unwrap();
         assert_eq!(result, PublishResult::Skipped(SkipReason::NoToken));

--- a/src/ecosystems/rust.rs
+++ b/src/ecosystems/rust.rs
@@ -319,6 +319,7 @@ impl RustAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     #[test]
@@ -493,6 +494,7 @@ my-dep = { version = \"1.0.0\" }\n";
     }
 
     #[test]
+    #[serial]
     fn publish_skipped_without_token() {
         let dir = TempDir::new().unwrap();
         let manifest = dir.path().join("Cargo.toml");

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -1,0 +1,87 @@
+use changelogs::ecosystems::{self, Ecosystem};
+use changelogs::{Package, PublishResult, SkipReason};
+use semver::Version;
+use serial_test::serial;
+use tempfile::TempDir;
+
+fn rust_package(dir: &std::path::Path) -> Package {
+    let manifest = dir.join("Cargo.toml");
+    std::fs::write(
+        &manifest,
+        "[package]\nname = \"my-binary\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    Package {
+        name: "my-binary".to_string(),
+        version: Version::new(1, 0, 0),
+        path: dir.to_path_buf(),
+        manifest_path: manifest,
+        dependencies: vec![],
+    }
+}
+
+/// Rust: absent `CARGO_REGISTRY_TOKEN` → `Skipped(NoToken)`, not an error.
+///
+/// Binary-only projects (e.g. foundry-rs/foundry) skip crates.io but still
+/// want git tags and GitHub releases. The publish step must succeed so the
+/// downstream tagging steps can run.
+#[test]
+#[serial]
+fn rust_publish_without_token_skips_silently() {
+    let dir = TempDir::new().unwrap();
+    let pkg = rust_package(dir.path());
+
+    // SAFETY: single-threaded test; no other test races on this env var.
+    unsafe {
+        std::env::remove_var("CARGO_REGISTRY_TOKEN");
+    }
+
+    let result = ecosystems::publish(Ecosystem::Rust, &pkg, false, None)
+        .expect("publish must not error when no registry token is configured");
+
+    assert_eq!(
+        result,
+        PublishResult::Skipped(SkipReason::NoToken),
+        "expected Skipped(NoToken) — git-tag creation must still proceed"
+    );
+}
+
+/// Python: absent `TWINE_PASSWORD` → `Skipped(NoToken)`, not an error.
+///
+/// The action always sets `TWINE_USERNAME=__token__`, so the no-token
+/// condition must be triggered by the absence of `TWINE_PASSWORD` alone.
+#[test]
+#[serial]
+fn python_publish_without_token_skips_silently() {
+    let dir = TempDir::new().unwrap();
+    let manifest = dir.path().join("pyproject.toml");
+    std::fs::write(
+        &manifest,
+        "[project]\nname = \"my-tool\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    let pkg = Package {
+        name: "my-tool".to_string(),
+        version: Version::new(1, 0, 0),
+        path: dir.path().to_path_buf(),
+        manifest_path: manifest,
+        dependencies: vec![],
+    };
+
+    // Mirror the action's real "no pypi-token" environment: TWINE_USERNAME is
+    // always set to __token__ by the action; TWINE_PASSWORD is what's absent.
+    // SAFETY: serialized via #[serial]; no concurrent env mutation.
+    unsafe {
+        std::env::remove_var("TWINE_PASSWORD");
+        std::env::set_var("TWINE_USERNAME", "__token__");
+    }
+
+    let result = ecosystems::publish(Ecosystem::Python, &pkg, false, None)
+        .expect("publish must not error when no registry token is configured");
+
+    assert_eq!(
+        result,
+        PublishResult::Skipped(SkipReason::NoToken),
+        "expected Skipped(NoToken) — git-tag creation must still proceed"
+    );
+}


### PR DESCRIPTION
Closes #65.

Binary-only projects (e.g. foundry-rs/foundry) release executables without publishing to crates.io or PyPI. This PR makes that workflow first-class.

Changes:
- action.yml: adds publish-mode input (registry default | tags-only) as a documentation alias. Behavior is unchanged: when no crate-token/pypi-token is provided the action already skips registry upload and creates git tags.
- README.md: adds publish-mode to the Action Inputs table and a new Tag-only publishing section with usage examples.
- tests/publish.rs: two integration tests verifying that ecosystems::publish() returns Skipped(NoToken) (not an error) for Rust and Python when no token is set.

The silent-skip path already exists via SkipReason::NoToken — this PR adds visibility and regression tests to keep that guarantee stable.